### PR TITLE
DeepEqualSlices - use the string representation of items

### DIFF
--- a/builtinutil/builtinutil.go
+++ b/builtinutil/builtinutil.go
@@ -23,13 +23,15 @@ func CastInterfaceToInterfaceSlice(slice interface{}) ([]interface{}, error) {
 
 // DeepEqualSlices ...
 func DeepEqualSlices(expected, actual []interface{}) bool {
-	expectedMap := map[interface{}]bool{}
+	expectedMap := map[string]bool{}
 	for _, itm := range expected {
-		expectedMap[itm] = true
+		itmAsStr := fmt.Sprintf("%#v", itm)
+		expectedMap[itmAsStr] = true
 	}
-	actualMap := map[interface{}]bool{}
+	actualMap := map[string]bool{}
 	for _, itm := range actual {
-		actualMap[itm] = true
+		itmAsStr := fmt.Sprintf("%#v", itm)
+		actualMap[itmAsStr] = true
 	}
 	return reflect.DeepEqual(expectedMap, actualMap)
 }

--- a/builtinutil/builtinutil_test.go
+++ b/builtinutil/builtinutil_test.go
@@ -28,29 +28,65 @@ func TestCastInterfaceToInterfaceSlice(t *testing.T) {
 }
 
 func TestDeepEqualSlices(t *testing.T) {
-	//
-	s1 := []string{"a", "b"}
-	interfaceS1, err := CastInterfaceToInterfaceSlice(s1)
-	require.NoError(t, err)
-	//
-	s2 := []string{"b", "a"}
-	interfaceS2, err := CastInterfaceToInterfaceSlice(s2)
-	require.NoError(t, err)
-	// equal, order doesn't matter
-	require.True(t, DeepEqualSlices(interfaceS1, interfaceS2))
+	{
+		//
+		s1 := []string{"a", "b"}
+		interfaceS1, err := CastInterfaceToInterfaceSlice(s1)
+		require.NoError(t, err)
+		//
+		s2 := []string{"b", "a"}
+		interfaceS2, err := CastInterfaceToInterfaceSlice(s2)
+		require.NoError(t, err)
+		// equal, order doesn't matter
+		require.True(t, DeepEqualSlices(interfaceS1, interfaceS2))
 
-	// NOT equal
-	s3 := []string{"b", "a", "c"}
-	interfaceS3, err := CastInterfaceToInterfaceSlice(s3)
-	require.NoError(t, err)
-	require.False(t, DeepEqualSlices(interfaceS1, interfaceS3))
+		// NOT equal
+		s3 := []string{"b", "a", "c"}
+		interfaceS3, err := CastInterfaceToInterfaceSlice(s3)
+		require.NoError(t, err)
+		require.False(t, DeepEqualSlices(interfaceS1, interfaceS3))
 
-	// NOT equal - same length but element differs
-	s4 := []string{"b", "x"}
-	interfaceS4, err := CastInterfaceToInterfaceSlice(s4)
-	require.NoError(t, err)
-	require.False(t, DeepEqualSlices(interfaceS1, interfaceS4))
+		// NOT equal - same length but element differs
+		s4 := []string{"b", "x"}
+		interfaceS4, err := CastInterfaceToInterfaceSlice(s4)
+		require.NoError(t, err)
+		require.False(t, DeepEqualSlices(interfaceS1, interfaceS4))
+	}
 
 	// empty
-	require.True(t, DeepEqualSlices([]interface{}{}, []interface{}{}))
+	{
+		require.True(t, DeepEqualSlices([]interface{}{}, []interface{}{}))
+	}
+
+	t.Log("Custom struct type")
+	{
+		type TestType struct {
+			StrKey   string
+			IntSlice []int
+		}
+		s1 := []TestType{
+			{StrKey: "key1", IntSlice: []int{1, 2}},
+			{StrKey: "key2", IntSlice: []int{3, 4, 5}},
+		}
+		s2 := []TestType{
+			{StrKey: "key2", IntSlice: []int{3, 4, 5}},
+			{StrKey: "key1", IntSlice: []int{1, 2}},
+		}
+
+		t.Log(" Should be equal")
+		interfaceS1, err := CastInterfaceToInterfaceSlice(s1)
+		require.NoError(t, err)
+		interfaceS2, err := CastInterfaceToInterfaceSlice(s2)
+		require.NoError(t, err)
+		require.True(t, DeepEqualSlices(interfaceS1, interfaceS2))
+
+		t.Log(" Should NOT be equal")
+		s3 := []TestType{
+			{StrKey: "key2", IntSlice: []int{3, 4, 5}},
+			{StrKey: "key3", IntSlice: []int{6, 7}},
+		}
+		interfaceS3, err := CastInterfaceToInterfaceSlice(s3)
+		require.NoError(t, err)
+		require.False(t, DeepEqualSlices(interfaceS1, interfaceS3))
+	}
 }


### PR DESCRIPTION
to overcome the "hash of unhashable type" issue

+ added custom struct slice test/example