### PR TITLE
expand log package

### DIFF
--- a/colorstring/colorstring.go
+++ b/colorstring/colorstring.go
@@ -19,8 +19,16 @@ const (
 	resetColor   Color = "\x1b[0m"
 )
 
+// ColorFunc ...
+type ColorFunc func(a ...interface{}) string
+
 func addColor(color Color, msg string) string {
 	return string(color) + msg + string(resetColor)
+}
+
+// NoColor ...
+func NoColor(a ...interface{}) string {
+	return fmt.Sprint(a...)
 }
 
 // Black ...
@@ -56,6 +64,14 @@ func Magenta(a ...interface{}) string {
 // Cyan ...
 func Cyan(a ...interface{}) string {
 	return addColor(cyanColor, fmt.Sprint(a...))
+}
+
+// ColorfFunc ...
+type ColorfFunc func(format string, a ...interface{}) string
+
+// NoColorf ...
+func NoColorf(format string, a ...interface{}) string {
+	return NoColor(fmt.Sprintf(format, a...))
 }
 
 // Blackf ...

--- a/log/json_logger.go
+++ b/log/json_logger.go
@@ -1,0 +1,37 @@
+package log
+
+import (
+	"fmt"
+	"io"
+	"os"
+)
+
+// JSONLoger ...
+type JSONLoger struct {
+	writer io.Writer
+}
+
+// NewJSONLoger ...
+func NewJSONLoger(writer io.Writer) *JSONLoger {
+	return &JSONLoger{
+		writer: writer,
+	}
+}
+
+// NewDefaultJSONLoger ...
+func NewDefaultJSONLoger() JSONLoger {
+	return JSONLoger{
+		writer: os.Stdout,
+	}
+}
+
+// PrintO ...
+func (l JSONLoger) PrintO(f Formatable) {
+	fmt.Fprintln(l.writer, f.JSON())
+}
+
+// Printf ...
+func (l JSONLoger) Printf(format string, a ...interface{}) {
+	str := fmt.Sprintf(format, a...)
+	l.PrintO(Message{Content: str})
+}

--- a/log/json_logger_test.go
+++ b/log/json_logger_test.go
@@ -1,0 +1,62 @@
+package log
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestJSONPrint(t *testing.T) {
+	t.Log("Default Formattable (Message)")
+	{
+		var b bytes.Buffer
+		logger := NewJSONLoger(&b)
+
+		logger.PrintO(Message{Content: "test"})
+		require.Equal(t, `{"content":"test"}`+"\n", b.String())
+	}
+
+	t.Log("Custom Formattable")
+	{
+		var b bytes.Buffer
+		logger := NewJSONLoger(&b)
+
+		test := TestFormattable{
+			a: "log",
+			b: "test",
+		}
+
+		logger.PrintO(test)
+		require.Equal(t, `{"a":"log","b":"test"}`+"\n", b.String())
+	}
+}
+
+func TestJSONPrintf(t *testing.T) {
+	t.Log("string")
+	{
+		var b bytes.Buffer
+		logger := NewJSONLoger(&b)
+
+		logger.Printf("test")
+		require.Equal(t, `{"content":"test"}`+"\n", b.String())
+	}
+
+	t.Log("format")
+	{
+		var b bytes.Buffer
+		logger := NewJSONLoger(&b)
+
+		logger.Printf("%s", "test")
+		require.Equal(t, `{"content":"test"}`+"\n", b.String())
+	}
+
+	t.Log("complex format")
+	{
+		var b bytes.Buffer
+		logger := NewJSONLoger(&b)
+
+		logger.Printf("%s %s", "log", "test")
+		require.Equal(t, `{"content":"log test"}`+"\n", b.String())
+	}
+}

--- a/log/log.go
+++ b/log/log.go
@@ -2,36 +2,99 @@ package log
 
 import (
 	"fmt"
+	"time"
+
+	"io"
+	"os"
 
 	"github.com/bitrise-io/go-utils/colorstring"
 )
 
-// Error ...
-func Error(format string, v ...interface{}) {
-	message := fmt.Sprintf(format, v...)
-	fmt.Println(colorstring.Red(message))
+//
+// Log configuration
+
+var timestampLayout = "15:04:05"
+
+// SetTimestampLayout ...
+func SetTimestampLayout(layout string) {
+	timestampLayout = layout
 }
 
-// Warn ...
-func Warn(format string, v ...interface{}) {
-	message := fmt.Sprintf(format, v...)
-	fmt.Println(colorstring.Yellow(message))
+var outWriter io.Writer = os.Stdout
+
+// SetOutWriter ...
+func SetOutWriter(writer io.Writer) {
+	outWriter = writer
 }
 
-// Info ...
-func Info(format string, v ...interface{}) {
-	message := fmt.Sprintf(format, v...)
-	fmt.Println(colorstring.Blue(message))
+//
+// Print with color
+
+func printfWithColor(color colorstring.ColorfFunc, format string, v ...interface{}) {
+	strWithColor := color(format, v...)
+	fmt.Fprintln(outWriter, strWithColor)
 }
 
-// Detail ...
-func Detail(format string, v ...interface{}) {
-	message := fmt.Sprintf(format, v...)
-	fmt.Println(message)
+// Printf ...
+func Printf(format string, v ...interface{}) {
+	printfWithColor(colorstring.NoColorf, format, v...)
 }
 
-// Done ...
-func Done(format string, v ...interface{}) {
-	message := fmt.Sprintf(format, v...)
-	fmt.Println(colorstring.Green(message))
+// Infof ...
+func Infof(format string, v ...interface{}) {
+	printfWithColor(colorstring.Bluef, format, v...)
+}
+
+// Donef ...
+func Donef(format string, v ...interface{}) {
+	printfWithColor(colorstring.Greenf, format, v...)
+}
+
+// Errorf ...
+func Errorf(format string, v ...interface{}) {
+	printfWithColor(colorstring.Redf, format, v...)
+}
+
+// Warnf ...
+func Warnf(format string, v ...interface{}) {
+	printfWithColor(colorstring.Yellowf, format, v...)
+}
+
+//
+// Print with color and timestamp
+
+func timestamp() string {
+	currentTime := time.Now()
+	return currentTime.Format(timestampLayout)
+}
+
+func printfWithColorAndTime(color colorstring.ColorfFunc, format string, v ...interface{}) {
+	strWithColor := color(format, v...)
+	strWithColorAndTime := fmt.Sprintf("[%s] %s", timestamp(), strWithColor)
+	fmt.Fprintln(outWriter, strWithColorAndTime)
+}
+
+// Printft ...
+func Printft(format string, v ...interface{}) {
+	printfWithColorAndTime(colorstring.NoColorf, format, v...)
+}
+
+// Infoft ...
+func Infoft(format string, v ...interface{}) {
+	printfWithColorAndTime(colorstring.Bluef, format, v...)
+}
+
+// Doneft ...
+func Doneft(format string, v ...interface{}) {
+	printfWithColorAndTime(colorstring.Greenf, format, v...)
+}
+
+// Errorft ...
+func Errorft(format string, v ...interface{}) {
+	printfWithColorAndTime(colorstring.Redf, format, v...)
+}
+
+// Warnft ...
+func Warnft(format string, v ...interface{}) {
+	printfWithColorAndTime(colorstring.Yellowf, format, v...)
 }

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -1,0 +1,81 @@
+package log
+
+import (
+	"bytes"
+	"testing"
+
+	"regexp"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPrintf(t *testing.T) {
+	t.Log("string")
+	{
+		var b bytes.Buffer
+		SetOutWriter(&b)
+
+		Printf("test")
+		require.Equal(t, "test\n", b.String())
+	}
+
+	t.Log("format")
+	{
+		var b bytes.Buffer
+		SetOutWriter(&b)
+
+		Printf("%s", "test")
+		require.Equal(t, "test\n", b.String())
+	}
+
+	t.Log("complex format")
+	{
+		var b bytes.Buffer
+		SetOutWriter(&b)
+
+		Printf("%s %s", "log", "test")
+		require.Equal(t, "log test\n", b.String())
+	}
+}
+
+func TestPrintft(t *testing.T) {
+	t.Log("string")
+	{
+		var b bytes.Buffer
+		SetOutWriter(&b)
+
+		Printft("test")
+
+		pattern := `\[.*\] test`
+		re := regexp.MustCompile(pattern)
+
+		require.Equal(t, true, re.MatchString(b.String()))
+	}
+
+	t.Log("format")
+	{
+		var b bytes.Buffer
+		SetOutWriter(&b)
+
+		Printft("%s", "test")
+
+		pattern := `\[.*\] test`
+		re := regexp.MustCompile(pattern)
+
+		require.Equal(t, true, re.MatchString(b.String()))
+	}
+
+	t.Log("complex format")
+	{
+		var b bytes.Buffer
+		SetOutWriter(&b)
+
+		Printft("%s %s", "log", "test")
+
+		pattern := `\[.*\] log test`
+		re := regexp.MustCompile(pattern)
+
+		require.Equal(t, true, re.MatchString(b.String()))
+	}
+
+}

--- a/log/logger.go
+++ b/log/logger.go
@@ -1,0 +1,54 @@
+package log
+
+import "fmt"
+import "encoding/json"
+
+// Logger ...
+type Logger interface {
+	PrintO(f Formatable)
+	Printf(format string, a ...interface{})
+}
+
+// Formatable ...
+type Formatable interface {
+	String() string
+	JSON() string
+}
+
+// Message ...
+type Message struct {
+	Content  interface{} `json:"content,omitempty"`
+	Error    string      `json:"error,omitempty"`
+	Warnings []string    `json:"warnings,omitempty"`
+}
+
+// String ...
+func (m Message) String() string {
+	msg := ""
+	if m.Error != "" {
+		msg = fmt.Sprintf("Error: %s", m.Error)
+	} else {
+		msg = fmt.Sprintf("%v", m.Content)
+	}
+
+	if len(m.Warnings) > 0 {
+		msg += fmt.Sprintf("\nWarnings:\n")
+		for i, warning := range m.Warnings {
+			msg = fmt.Sprintf("- %s", warning)
+			if i != len(m.Warnings)-1 {
+				msg += "\n"
+			}
+		}
+	}
+
+	return msg
+}
+
+// JSON ...
+func (m Message) JSON() string {
+	bytes, err := json.Marshal(m)
+	if err != nil {
+		return fmt.Sprintf(`"Error: %s"`, err)
+	}
+	return string(bytes)
+}

--- a/log/raw_logger.go
+++ b/log/raw_logger.go
@@ -1,0 +1,37 @@
+package log
+
+import (
+	"fmt"
+	"io"
+	"os"
+)
+
+// RawLogger ...
+type RawLogger struct {
+	writer io.Writer
+}
+
+// NewRawLogger ...
+func NewRawLogger(writer io.Writer) *RawLogger {
+	return &RawLogger{
+		writer: writer,
+	}
+}
+
+// NewDefaultRawLogger ...
+func NewDefaultRawLogger() RawLogger {
+	return RawLogger{
+		writer: os.Stdout,
+	}
+}
+
+// PrintO ...
+func (l RawLogger) PrintO(f Formatable) {
+	fmt.Fprintln(l.writer, f.String())
+}
+
+// Printf ...
+func (l RawLogger) Printf(format string, a ...interface{}) {
+	str := fmt.Sprintf(format, a...)
+	l.PrintO(Message{Content: str})
+}

--- a/log/raw_logger_test.go
+++ b/log/raw_logger_test.go
@@ -1,0 +1,78 @@
+package log
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type TestFormattable struct {
+	a string
+	b string
+}
+
+// String ...
+func (f TestFormattable) String() string {
+	return fmt.Sprintf("%s %s", f.a, f.b)
+}
+
+// JSON ...
+func (f TestFormattable) JSON() string {
+	return fmt.Sprintf(`{"a":"%s","b":"%s"}`, f.a, f.b)
+}
+
+func TestRawPrint(t *testing.T) {
+	t.Log("Default Formattable (Message)")
+	{
+		var b bytes.Buffer
+		logger := NewRawLogger(&b)
+
+		logger.PrintO(Message{Content: "test"})
+		require.Equal(t, "test\n", b.String())
+	}
+
+	t.Log("Custom Formattable")
+	{
+		var b bytes.Buffer
+		logger := NewRawLogger(&b)
+
+		test := TestFormattable{
+			a: "log",
+			b: "test",
+		}
+
+		logger.PrintO(test)
+		require.Equal(t, "log test\n", b.String())
+	}
+}
+
+func TestRawPrintf(t *testing.T) {
+	t.Log("string")
+	{
+		var b bytes.Buffer
+		logger := NewRawLogger(&b)
+
+		logger.Printf("test")
+		require.Equal(t, "test\n", b.String())
+	}
+
+	t.Log("format")
+	{
+		var b bytes.Buffer
+		logger := NewRawLogger(&b)
+
+		logger.Printf("%s", "test")
+		require.Equal(t, "test\n", b.String())
+	}
+
+	t.Log("complex format")
+	{
+		var b bytes.Buffer
+		logger := NewRawLogger(&b)
+
+		logger.Printf("%s %s", "log", "test")
+		require.Equal(t, "log test\n", b.String())
+	}
+}


### PR DESCRIPTION
# colorstring package:

- ColorFunc & ColorfFunc, to allow refer to the coloring functions with type (`printfWithColor(color colorstring.ColorfFunc, format string, v ...interface{})`)
- NoColor & NoColorf, to allow print without color

```
func Printf(format string, v ...interface{}) {
  printfWithColor(colorstring.NoColorf, format, v...)
}
```

# log package:

- formatted logging method names got `f` suffix, to be consistent
- Logger interface, Formatable interface & default Message struct
- JSON and Raw Loggers