### PR TITLE
Support new ruby path

### DIFF
--- a/command/rubycommand/rubycommand.go
+++ b/command/rubycommand/rubycommand.go
@@ -13,8 +13,9 @@ import (
 )
 
 const (
-	systemRubyPth = "/usr/bin/ruby"
-	brewRubyPth   = "/usr/local/bin/ruby"
+	systemRubyPth  = "/usr/bin/ruby"
+	brewRubyPth    = "/usr/local/bin/ruby"
+	brewRubyPthAlt = "/usr/local/opt/ruby/bin/ruby"
 )
 
 // InstallType ...
@@ -56,6 +57,8 @@ func installType() InstallType {
 	if whichRuby == systemRubyPth {
 		installType = SystemRuby
 	} else if whichRuby == brewRubyPth {
+		installType = BrewRuby
+	} else if whichRuby == brewRubyPthAlt {
 		installType = BrewRuby
 	} else if cmdExist("rvm", "-v") {
 		installType = RVMRuby


### PR DESCRIPTION
```sh
$PATH=/Users/vagrant/.bitrise/tools:/usr/local/opt/ruby/bin:/usr/local/bin:/usr/local/sbin:~/bin:/usr/local/bin:...
```
Current mac build use `/usr/local/opt/ruby/bin` in `PATH` as resolved ruby path, which will get Unknown install type when running ruby script (like CocoaPods). This patch should fix this.