### PR TITLE
Internal logging

### DIFF
--- a/log/defaultlogger.go
+++ b/log/defaultlogger.go
@@ -47,7 +47,7 @@ func (dl DefaultLogger) Debugf(format string, v ...interface{}) {
 	}
 }
 
-type logfunc func(string, ...interface{}) Entry
+type logfunc func(string, ...interface{})
 
 func fSelect(t bool, tf logfunc, f logfunc) logfunc {
 	if t {

--- a/log/defaultlogger.go
+++ b/log/defaultlogger.go
@@ -47,7 +47,7 @@ func (dl DefaultLogger) Debugf(format string, v ...interface{}) {
 	}
 }
 
-type logfunc func(string, ...interface{}) Message
+type logfunc func(string, ...interface{}) Entry
 
 func fSelect(t bool, tf logfunc, f logfunc) logfunc {
 	if t {

--- a/log/defaultlogger.go
+++ b/log/defaultlogger.go
@@ -47,7 +47,7 @@ func (dl DefaultLogger) Debugf(format string, v ...interface{}) {
 	}
 }
 
-type logfunc func(string, ...interface{}) logMessage
+type logfunc func(string, ...interface{}) Message
 
 func fSelect(t bool, tf logfunc, f logfunc) logfunc {
 	if t {

--- a/log/defaultlogger.go
+++ b/log/defaultlogger.go
@@ -47,7 +47,7 @@ func (dl DefaultLogger) Debugf(format string, v ...interface{}) {
 	}
 }
 
-type logfunc func(string, ...interface{})
+type logfunc func(string, ...interface{}) logMessage
 
 func fSelect(t bool, tf logfunc, f logfunc) logfunc {
 	if t {

--- a/log/internal_logger.go
+++ b/log/internal_logger.go
@@ -25,25 +25,27 @@ func init() {
 
 // SendToInternal sends the log message to the configured analytics server
 func (lm Message) SendToInternal(stepID, tag string, data map[string]interface{}) {
-	for k, v := range data {
-		lm.Data[k] = v
-	}
-
-	lm.Data["step_id"] = stepID
-	lm.Data["tag"] = tag
-
-	b, err := json.Marshal(lm)
-	if err != nil {
-		fmt.Printf("marshal log message: %s\n", err)
-	}
-
-	resp, err := http.Post(analyticsServerURL + "/logs", "application/json", bytes.NewReader(b))
-	if err != nil {
-		fmt.Printf("post log message: %s\n", err)
-	}
-
-	if resp.StatusCode != 200 {
-		fmt.Printf("post log message response: %s %s\n", resp.Status, resp.Body)
+	if enableDebugLog {
+		for k, v := range data {
+			lm.Data[k] = v
+		}
+	
+		lm.Data["step_id"] = stepID
+		lm.Data["tag"] = tag
+	
+		b, err := json.Marshal(lm)
+		if err != nil {
+			fmt.Printf("marshal log message: %s\n", err)
+		}
+	
+		resp, err := http.Post(analyticsServerURL + "/logs", "application/json", bytes.NewReader(b))
+		if err != nil {
+			fmt.Printf("post log message: %s\n", err)
+		}
+	
+		if resp.StatusCode != 200 {
+			fmt.Printf("post log message response: %s %s\n", resp.Status, resp.Body)
+		}	
 	}
 }
 

--- a/log/internal_logger.go
+++ b/log/internal_logger.go
@@ -52,19 +52,16 @@ func (e Entry) Internal(stepID, tag string, data map[string]interface{}) {
 		return
 	}
 
-	ctx, cancel := context.WithCancel(context.TODO())
-	_ = time.AfterFunc(3 * time.Second, func() {
-		cancel()
-	})
-
+	ctx, cancel := context.WithTimeout(context.Background(), 3 * time.Second)
+	defer cancel()
+	
 	req, err := http.NewRequest(http.MethodPost, analyticsServerURL  + "/logs", &b)
 	if err != nil {
 		// deliberately not writing into users log
 		return
 	}
-	
-	req.Header.Add("Content-Type", "application/json")
 	req = req.WithContext(ctx)
+	req.Header.Add("Content-Type", "application/json")
 	
 	if _, err := httpClient.Do(req); err != nil {
 		// deliberately not writing into users log

--- a/log/internal_logger.go
+++ b/log/internal_logger.go
@@ -1,0 +1,12 @@
+package log
+
+type logMessage struct{
+	LogLevel string `json:"log_level"`
+	Message string `json:"message"`
+	Data map[string]interface{} `json:"data"`
+}
+
+func (lm logMessage) SendToInternal(stepID, tag string, data map[string]interface{}) {
+	// todo: post to analytics server
+}
+

--- a/log/internal_logger.go
+++ b/log/internal_logger.go
@@ -27,6 +27,13 @@ func (lm Message) SendToInternal(stepID, tag string, data map[string]interface{}
 		lm.Data[k] = v
 	}
 
+	if v, ok := lm.Data["step_id"]; ok {
+		fmt.Printf("internal logger: data.step_id (%s) will be overriden with (%s) ", v, stepID)
+	}
+	if v, ok := lm.Data["tag"]; ok {
+		fmt.Printf("internal logger: data.tag (%s) will be overriden with (%s) ", v, tag)
+	}
+
 	lm.Data["step_id"] = stepID
 	lm.Data["tag"] = tag
 

--- a/log/internal_logger.go
+++ b/log/internal_logger.go
@@ -10,7 +10,8 @@ import (
 
 var analyticsServerURL = "https://bitrise-step-analytics.herokuapp.com"
 
-type logMessage struct{
+// Message represents a line in a log
+type Message struct{
 	LogLevel string `json:"log_level"`
 	Message string `json:"message"`
 	Data map[string]interface{} `json:"data"`
@@ -22,7 +23,8 @@ func init() {
 	}
 }
 
-func (lm logMessage) SendToInternal(stepID, tag string, data map[string]interface{}) {
+// SendToInternal sends the log message to the configured analytics server
+func (lm Message) SendToInternal(stepID, tag string, data map[string]interface{}) {
 	for k, v := range data {
 		lm.Data[k] = v
 	}

--- a/log/internal_logger.go
+++ b/log/internal_logger.go
@@ -15,8 +15,8 @@ var (
 	}
 )
 
-// Message represents a line in a log
-type Message struct{
+// Entry represents a line in a log
+type Entry struct{
 	LogLevel string `json:"log_level"`
 	Message string `json:"message"`
 	Data map[string]interface{} `json:"data"`
@@ -30,7 +30,7 @@ func SetAnalyticsServerURL(url string) {
 }
 
 // Internal sends the log message to the configured analytics server
-func (lm Message) Internal(stepID, tag string, data map[string]interface{}) {
+func (lm Entry) Internal(stepID, tag string, data map[string]interface{}) {
 	lm.Data = make(map[string]interface{})
 	for k, v := range data {
 		lm.Data[k] = v

--- a/log/internal_logger.go
+++ b/log/internal_logger.go
@@ -2,6 +2,7 @@ package log
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -51,9 +52,24 @@ func (lm Entry) Internal(stepID, tag string, data map[string]interface{}) {
 		return
 	}
 
-	go func() {
-		if _, err := netClient.Post(analyticsServerURL + "/logs", "application/json", &b); err != nil {}
-	}()
+	ctx, cancel := context.WithCancel(context.TODO())
+	_ = time.AfterFunc(3 * time.Second, func() {
+		cancel()
+	})
+
+	req, err := http.NewRequest(http.MethodPost, analyticsServerURL  + "/logs", &b)
+	if err != nil {
+		// deliberately not writing into users log
+		return
+	}
+	
+	req.Header.Add("Content-Type", "application/json")
+	req = req.WithContext(ctx)
+	
+	if _, err := netClient.Do(req); err != nil {
+		// deliberately not writing into users log
+		return
+	}
 
 }
 

--- a/log/internal_logger.go
+++ b/log/internal_logger.go
@@ -31,7 +31,12 @@ func SetAnalyticsServerURL(url string) {
 }
 
 // Internal sends the log message to the configured analytics server
-func (e Entry) Internal(stepID, tag string, data map[string]interface{}) {
+func rprintf(logLevel string, stepID string, tag string, data map[string]interface{}, format string, v ...interface{}) {
+	e := Entry{
+		Message: fmt.Sprintf(format, v...),
+		LogLevel: logLevel,
+	}
+	
 	e.Data = make(map[string]interface{})
 	for k, v := range data {
 		e.Data[k] = v

--- a/log/internal_logger.go
+++ b/log/internal_logger.go
@@ -25,27 +25,30 @@ func init() {
 
 // SendToInternal sends the log message to the configured analytics server
 func (lm Message) SendToInternal(stepID, tag string, data map[string]interface{}) {
-	if enableDebugLog {
-		for k, v := range data {
-			lm.Data[k] = v
-		}
-	
-		lm.Data["step_id"] = stepID
-		lm.Data["tag"] = tag
-	
-		b, err := json.Marshal(lm)
-		if err != nil {
-			fmt.Printf("marshal log message: %s\n", err)
-		}
-	
-		resp, err := http.Post(analyticsServerURL + "/logs", "application/json", bytes.NewReader(b))
-		if err != nil {
-			fmt.Printf("post log message: %s\n", err)
-		}
-	
-		if resp.StatusCode != 200 {
-			fmt.Printf("post log message response: %s %s\n", resp.Status, resp.Body)
-		}	
+	if lm.LogLevel == "" {
+		return
+	}
+
+	lm.Data = make(map[string]interface{})
+	for k, v := range data {
+		lm.Data[k] = v
+	}
+
+	lm.Data["step_id"] = stepID
+	lm.Data["tag"] = tag
+
+	b, err := json.Marshal(lm)
+	if err != nil {
+		fmt.Printf("marshal log message: %s\n", err)
+	}
+
+	resp, err := http.Post(analyticsServerURL + "/logs", "application/json", bytes.NewReader(b))
+	if err != nil {
+		fmt.Printf("post log message: %s\n", err)
+	}
+
+	if resp.StatusCode != 200 {
+		fmt.Printf("post log message response: %s %s\n", resp.Status, resp.Body)
 	}
 }
 

--- a/log/internal_logger.go
+++ b/log/internal_logger.go
@@ -48,6 +48,7 @@ func (lm Message) Internal(stepID, tag string, data map[string]interface{}) {
 	var b bytes.Buffer
 	if err := json.NewEncoder(&b).Encode(lm); err != nil {
 		fmt.Printf("json encode log message: %s\n", err)
+		return
 	}
 
 	resp, err := netClient.Post(analyticsServerURL + "/logs", "application/json", &b)

--- a/log/internal_logger.go
+++ b/log/internal_logger.go
@@ -47,17 +47,10 @@ func (lm Message) Internal(stepID, tag string, data map[string]interface{}) {
 
 	var b bytes.Buffer
 	if err := json.NewEncoder(&b).Encode(lm); err != nil {
-		fmt.Printf("json encode log message: %s\n", err)
 		return
 	}
 
-	resp, err := netClient.Post(analyticsServerURL + "/logs", "application/json", &b)
-	if err != nil {
-		fmt.Printf("post log message: %s\n", err)
-	}
-
-	if resp.StatusCode != 200 {
-		fmt.Printf("post log message response: %s %s\n", resp.Status, resp.Body)
-	}
+	_, err := netClient.Post(analyticsServerURL + "/logs", "application/json", &b)
+	if err != nil {}
 }
 

--- a/log/internal_logger.go
+++ b/log/internal_logger.go
@@ -27,7 +27,7 @@ func SetAnalyticsServerURL(url string) {
 }
 
 // SendToInternal sends the log message to the configured analytics server
-func (lm Message) SendToInternal(stepID, tag string, data map[string]interface{}) {
+func (lm Message) Internal(stepID, tag string, data map[string]interface{}) {
 	lm.Data = make(map[string]interface{})
 	for k, v := range data {
 		lm.Data[k] = v

--- a/log/internal_logger.go
+++ b/log/internal_logger.go
@@ -5,9 +5,15 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"time"
 )
 
-var analyticsServerURL = "https://bitrise-step-analytics.herokuapp.com"
+var (
+	analyticsServerURL = "https://bitrise-step-analytics.herokuapp.com"
+	netClient = http.Client{
+		Timeout: time.Second * 5,
+	}
+)
 
 // Message represents a line in a log
 type Message struct{
@@ -42,7 +48,7 @@ func (lm Message) SendToInternal(stepID, tag string, data map[string]interface{}
 		fmt.Printf("marshal log message: %s\n", err)
 	}
 
-	resp, err := http.Post(analyticsServerURL + "/logs", "application/json", bytes.NewReader(b))
+	resp, err := netClient.Post(analyticsServerURL + "/logs", "application/json", bytes.NewReader(b))
 	if err != nil {
 		fmt.Printf("post log message: %s\n", err)
 	}

--- a/log/internal_logger.go
+++ b/log/internal_logger.go
@@ -43,12 +43,12 @@ func (lm Message) Internal(stepID, tag string, data map[string]interface{}) {
 	lm.Data["step_id"] = stepID
 	lm.Data["tag"] = tag
 
-	b, err := json.Marshal(lm)
-	if err != nil {
-		fmt.Printf("marshal log message: %s\n", err)
+	var b bytes.Buffer
+	if err := json.NewEncoder(&b).Encode(lm); err != nil {
+		fmt.Printf("json encode log message: %s\n", err)
 	}
 
-	resp, err := netClient.Post(analyticsServerURL + "/logs", "application/json", bytes.NewReader(b))
+	resp, err := netClient.Post(analyticsServerURL + "/logs", "application/json", &b)
 	if err != nil {
 		fmt.Printf("post log message: %s\n", err)
 	}

--- a/log/internal_logger.go
+++ b/log/internal_logger.go
@@ -11,16 +11,16 @@ import (
 
 var (
 	analyticsServerURL = "https://bitrise-step-analytics.herokuapp.com"
-	httpClient = http.Client{
+	httpClient         = http.Client{
 		Timeout: time.Second * 5,
 	}
 )
 
 // Entry represents a line in a log
-type Entry struct{
-	LogLevel string `json:"log_level"`
-	Message string `json:"message"`
-	Data map[string]interface{} `json:"data"`
+type Entry struct {
+	LogLevel string                 `json:"log_level"`
+	Message  string                 `json:"message"`
+	Data     map[string]interface{} `json:"data"`
 }
 
 // SetAnalyticsServerURL updates the the analytics server collecting the
@@ -33,10 +33,10 @@ func SetAnalyticsServerURL(url string) {
 // Internal sends the log message to the configured analytics server
 func rprintf(logLevel string, stepID string, tag string, data map[string]interface{}, format string, v ...interface{}) {
 	e := Entry{
-		Message: fmt.Sprintf(format, v...),
+		Message:  fmt.Sprintf(format, v...),
 		LogLevel: logLevel,
 	}
-	
+
 	e.Data = make(map[string]interface{})
 	for k, v := range data {
 		e.Data[k] = v
@@ -57,21 +57,20 @@ func rprintf(logLevel string, stepID string, tag string, data map[string]interfa
 		return
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 3 * time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
-	
-	req, err := http.NewRequest(http.MethodPost, analyticsServerURL  + "/logs", &b)
+
+	req, err := http.NewRequest(http.MethodPost, analyticsServerURL+"/logs", &b)
 	if err != nil {
 		// deliberately not writing into users log
 		return
 	}
 	req = req.WithContext(ctx)
 	req.Header.Add("Content-Type", "application/json")
-	
+
 	if _, err := httpClient.Do(req); err != nil {
 		// deliberately not writing into users log
 		return
 	}
 
 }
-

--- a/log/internal_logger.go
+++ b/log/internal_logger.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"os"
 	"net/http"
 )
 
@@ -17,10 +16,8 @@ type Message struct{
 	Data map[string]interface{} `json:"data"`
 }
 
-func init() {
-	if url := os.Getenv("ANALYTICS_SERVER_URL"); url != "" {
-		analyticsServerURL = url
-	}
+func SetAnalyticsServerURL(url string) {
+	analyticsServerURL = url
 }
 
 // SendToInternal sends the log message to the configured analytics server

--- a/log/internal_logger.go
+++ b/log/internal_logger.go
@@ -23,7 +23,8 @@ type Message struct{
 }
 
 // SetAnalyticsServerURL updates the the analytics server collecting the
-// logs.
+// logs. It is intended for use during tests. Warning: current implementation
+// is not thread safe, do not call the function during runtime.
 func SetAnalyticsServerURL(url string) {
 	analyticsServerURL = url
 }
@@ -50,7 +51,9 @@ func (lm Message) Internal(stepID, tag string, data map[string]interface{}) {
 		return
 	}
 
-	_, err := netClient.Post(analyticsServerURL + "/logs", "application/json", &b)
-	if err != nil {}
+	go func() {
+		if _, err := netClient.Post(analyticsServerURL + "/logs", "application/json", &b); err != nil {}
+	}()
+
 }
 

--- a/log/internal_logger.go
+++ b/log/internal_logger.go
@@ -1,5 +1,12 @@
 package log
 
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
 type logMessage struct{
 	LogLevel string `json:"log_level"`
 	Message string `json:"message"`
@@ -7,6 +14,25 @@ type logMessage struct{
 }
 
 func (lm logMessage) SendToInternal(stepID, tag string, data map[string]interface{}) {
-	// todo: post to analytics server
+	for k, v := range data {
+		lm.Data[k] = v
+	}
+
+	lm.Data["step_id"] = stepID
+	lm.Data["tag"] = tag
+
+	b, err := json.Marshal(lm)
+	if err != nil {
+		fmt.Printf("marshal log message: %s\n", err)
+	}
+
+	resp, err := http.Post("https://bitrise-step-analytics.herokuapp.com/logs", "application/json", bytes.NewReader(b))
+	if err != nil {
+		fmt.Printf("post log message: %s\n", err)
+	}
+
+	if resp.StatusCode != 200 {
+		fmt.Printf("post log message response: %s %s\n", resp.Status, resp.Body)
+	}
 }
 

--- a/log/internal_logger.go
+++ b/log/internal_logger.go
@@ -4,13 +4,22 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"os"
 	"net/http"
 )
+
+var analyticsServerURL = "https://bitrise-step-analytics.herokuapp.com"
 
 type logMessage struct{
 	LogLevel string `json:"log_level"`
 	Message string `json:"message"`
 	Data map[string]interface{} `json:"data"`
+}
+
+func init() {
+	if url := os.Getenv("ANALYTICS_SERVER_URL"); url != "" {
+		analyticsServerURL = url
+	}
 }
 
 func (lm logMessage) SendToInternal(stepID, tag string, data map[string]interface{}) {
@@ -26,7 +35,7 @@ func (lm logMessage) SendToInternal(stepID, tag string, data map[string]interfac
 		fmt.Printf("marshal log message: %s\n", err)
 	}
 
-	resp, err := http.Post("https://bitrise-step-analytics.herokuapp.com/logs", "application/json", bytes.NewReader(b))
+	resp, err := http.Post(analyticsServerURL + "/logs", "application/json", bytes.NewReader(b))
 	if err != nil {
 		fmt.Printf("post log message: %s\n", err)
 	}

--- a/log/internal_logger.go
+++ b/log/internal_logger.go
@@ -31,24 +31,24 @@ func SetAnalyticsServerURL(url string) {
 }
 
 // Internal sends the log message to the configured analytics server
-func (lm Entry) Internal(stepID, tag string, data map[string]interface{}) {
-	lm.Data = make(map[string]interface{})
+func (e Entry) Internal(stepID, tag string, data map[string]interface{}) {
+	e.Data = make(map[string]interface{})
 	for k, v := range data {
-		lm.Data[k] = v
+		e.Data[k] = v
 	}
 
-	if v, ok := lm.Data["step_id"]; ok {
+	if v, ok := e.Data["step_id"]; ok {
 		fmt.Printf("internal logger: data.step_id (%s) will be overriden with (%s) ", v, stepID)
 	}
-	if v, ok := lm.Data["tag"]; ok {
+	if v, ok := e.Data["tag"]; ok {
 		fmt.Printf("internal logger: data.tag (%s) will be overriden with (%s) ", v, tag)
 	}
 
-	lm.Data["step_id"] = stepID
-	lm.Data["tag"] = tag
+	e.Data["step_id"] = stepID
+	e.Data["tag"] = tag
 
 	var b bytes.Buffer
-	if err := json.NewEncoder(&b).Encode(lm); err != nil {
+	if err := json.NewEncoder(&b).Encode(e); err != nil {
 		return
 	}
 

--- a/log/internal_logger.go
+++ b/log/internal_logger.go
@@ -11,7 +11,7 @@ import (
 
 var (
 	analyticsServerURL = "https://bitrise-step-analytics.herokuapp.com"
-	netClient = http.Client{
+	httpClient = http.Client{
 		Timeout: time.Second * 5,
 	}
 )
@@ -66,7 +66,7 @@ func (e Entry) Internal(stepID, tag string, data map[string]interface{}) {
 	req.Header.Add("Content-Type", "application/json")
 	req = req.WithContext(ctx)
 	
-	if _, err := netClient.Do(req); err != nil {
+	if _, err := httpClient.Do(req); err != nil {
 		// deliberately not writing into users log
 		return
 	}

--- a/log/internal_logger.go
+++ b/log/internal_logger.go
@@ -23,7 +23,7 @@ type Message struct{
 }
 
 // SetAnalyticsServerURL updates the the analytics server collecting the
-// logs. Default value is 'https://bitrise-step-analytics.herokuapp.com'
+// logs.
 func SetAnalyticsServerURL(url string) {
 	analyticsServerURL = url
 }

--- a/log/internal_logger.go
+++ b/log/internal_logger.go
@@ -25,10 +25,6 @@ func init() {
 
 // SendToInternal sends the log message to the configured analytics server
 func (lm Message) SendToInternal(stepID, tag string, data map[string]interface{}) {
-	if lm.LogLevel == "" {
-		return
-	}
-
 	lm.Data = make(map[string]interface{})
 	for k, v := range data {
 		lm.Data[k] = v

--- a/log/internal_logger.go
+++ b/log/internal_logger.go
@@ -22,11 +22,13 @@ type Message struct{
 	Data map[string]interface{} `json:"data"`
 }
 
+// SetAnalyticsServerURL updates the the analytics server collecting the
+// logs. Default value is 'https://bitrise-step-analytics.herokuapp.com'
 func SetAnalyticsServerURL(url string) {
 	analyticsServerURL = url
 }
 
-// SendToInternal sends the log message to the configured analytics server
+// Internal sends the log message to the configured analytics server
 func (lm Message) Internal(stepID, tag string, data map[string]interface{}) {
 	lm.Data = make(map[string]interface{})
 	for k, v := range data {

--- a/log/print.go
+++ b/log/print.go
@@ -4,15 +4,18 @@ import (
 	"fmt"
 )
 
-func printf(severity Severity, withTime bool, format string, v ...interface{}) string {
+func printf(severity Severity, withTime bool, format string, v ...interface{}) {
+	message := createLogMsg(severity, withTime, format, v...)
+	if _, err := fmt.Fprintln(outWriter, message); err != nil {
+		fmt.Printf("failed to print message: %s, error: %s\n", message, err)
+	}
+}
+
+func createLogMsg(severity Severity, withTime bool, format string, v ...interface{}) string {
 	colorFunc := severityColorFuncMap[severity]
 	message := colorFunc(format, v...)
 	if withTime {
 		message = fmt.Sprintf("%s %s", timestampField(), message)
-	}
-
-	if _, err := fmt.Fprintln(outWriter, message); err != nil {
-		fmt.Printf("failed to print message: %s, error: %s\n", message, err)
 	}
 
 	return message
@@ -20,9 +23,10 @@ func printf(severity Severity, withTime bool, format string, v ...interface{}) s
 
 // Successf ...
 func Successf(format string, v ...interface{}) Message {
+	printf(successSeverity, false, format, v...)
 	return Message{
 		LogLevel: "info",
-		Message: printf(successSeverity, false, format, v...),
+		Message: createLogMsg(successSeverity, false, format, v...),
 	}
 }
 
@@ -33,107 +37,110 @@ func Donef(format string, v ...interface{}) Message {
 
 // Infof ...
 func Infof(format string, v ...interface{}) Message {
+	printf(infoSeverity, false, format, v...)
 	return Message{
 		LogLevel: "info",
-		Message: printf(infoSeverity, false, format, v...),
+		Message: createLogMsg(infoSeverity, false, format, v...),
 	}
 }
 
 // Printf ...
 func Printf(format string, v ...interface{}) Message {
+	printf(normalSeverity, false, format, v...)
 	return Message{
 		LogLevel: "info",
-		Message: printf(normalSeverity, false, format, v...),
+		Message: createLogMsg(normalSeverity, false, format, v...),
 	}
 }
 
 // Debugf ...
 func Debugf(format string, v ...interface{}) Message {
 	if enableDebugLog {
-		return Message{
-			LogLevel: "info",
-			Message: printf(debugSeverity, false, format, v...),
-		}
+		printf(debugSeverity, false, format, v...)
 	}
 
 	return Message{
-		LogLevel: "",
-		Message: "",
+		LogLevel: "info",
+		Message: createLogMsg(debugSeverity, false, format, v...),
 	}
 }
 
 // Warnf ...
 func Warnf(format string, v ...interface{}) Message {
+	printf(warnSeverity, false, format, v...)
 	return Message{
 		LogLevel: "warn",
-		Message: printf(warnSeverity, false, format, v...),
+		Message: createLogMsg(warnSeverity, false, format, v...),
 	}
 }
 
 // Errorf ...
 func Errorf(format string, v ...interface{}) Message {
+	printf(errorSeverity, false, format, v...)
 	return Message{
 		LogLevel: "error",
-		Message: printf(errorSeverity, false, format, v...),
+		Message: createLogMsg(errorSeverity, false, format, v...),
 	}
 }
 
 // TSuccessf ...
 func TSuccessf(format string, v ...interface{}) Message {
+	printf(successSeverity, true, format, v...)
 	return Message{
 		LogLevel: "info",
-		Message: printf(successSeverity, true, format, v...),
+		Message: createLogMsg(successSeverity, true, format, v...),
 	}
 }
 
 // TDonef ...
 func TDonef(format string, v ...interface{}) Message {
-	return TSuccessf(format, v...)
+	return TSuccessf(successSeverity, true, format, v...)
 }
 
 // TInfof ...
 func TInfof(format string, v ...interface{}) Message {
+	printf(infoSeverity, true, format, v...)
 	return Message{
 		LogLevel: "info",
-		Message: printf(infoSeverity, true, format, v...),
+		Message: createLogMsg(infoSeverity, true, format, v...),
 	}
 }
 
 // TPrintf ...
 func TPrintf(format string, v ...interface{}) Message {
+	printf(normalSeverity, true, format, v...)
 	return Message{
 		LogLevel: "info",
-		Message: printf(normalSeverity, true, format, v...),
+		Message: createLogMsg(normalSeverity, true, format, v...),
 	}
 }
 
 // TDebugf ...
 func TDebugf(format string, v ...interface{}) Message {
 	if enableDebugLog {
-		return Message{
-			LogLevel: "info",
-			Message: printf(debugSeverity, true, format, v...),
-		}
+		printf(debugSeverity, true, format, v...)
 	}
 
 	return Message{
-		LogLevel: "",
-		Message: "",
+		LogLevel: "info",
+		Message: createLogMsg(debugSeverity, true, format, v...),
 	}
 }
 
 // TWarnf ...
 func TWarnf(format string, v ...interface{}) Message {
+	printf(warnSeverity, true, format, v...)
 	return Message{
 		LogLevel: "warn",
-		Message: printf(warnSeverity, true, format, v...),
+		Message: createLogMsg(warnSeverity, true, format, v...),
 	}
 }
 
 // TErrorf ...
 func TErrorf(format string, v ...interface{}) Message {
+	printf(errorSeverity, true, format, v...)
 	return Message{
 		LogLevel: "error",
-		Message: printf(errorSeverity, true, format, v...),
+		Message: createLogMsg(errorSeverity, true, format, v...),
 	}
 }

--- a/log/print.go
+++ b/log/print.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 )
 
-func printf(severity Severity, withTime bool, format string, v ...interface{}) {
+func printf(severity Severity, withTime bool, format string, v ...interface{}) string {
 	colorFunc := severityColorFuncMap[severity]
 	message := colorFunc(format, v...)
 	if withTime {
@@ -14,78 +14,126 @@ func printf(severity Severity, withTime bool, format string, v ...interface{}) {
 	if _, err := fmt.Fprintln(outWriter, message); err != nil {
 		fmt.Printf("failed to print message: %s, error: %s\n", message, err)
 	}
+
+	return message
 }
 
 // Successf ...
-func Successf(format string, v ...interface{}) {
-	printf(successSeverity, false, format, v...)
+func Successf(format string, v ...interface{}) logMessage {
+	return logMessage{
+		LogLevel: "info",
+		Message: printf(successSeverity, false, format, v...),
+	}
 }
 
 // Donef ...
-func Donef(format string, v ...interface{}) {
-	Successf(format, v...)
+func Donef(format string, v ...interface{}) logMessage {
+	return Successf(format, v...)
 }
 
 // Infof ...
-func Infof(format string, v ...interface{}) {
-	printf(infoSeverity, false, format, v...)
+func Infof(format string, v ...interface{}) logMessage {
+	return logMessage{
+		LogLevel: "info",
+		Message: printf(infoSeverity, false, format, v...),
+	}
 }
 
 // Printf ...
-func Printf(format string, v ...interface{}) {
-	printf(normalSeverity, false, format, v...)
+func Printf(format string, v ...interface{}) logMessage {
+	return logMessage{
+		LogLevel: "info",
+		Message: printf(normalSeverity, false, format, v...),
+	}
 }
 
 // Debugf ...
-func Debugf(format string, v ...interface{}) {
+func Debugf(format string, v ...interface{}) logMessage {
 	if enableDebugLog {
-		printf(debugSeverity, false, format, v...)
+		return logMessage{
+			LogLevel: "info",
+			Message: printf(debugSeverity, false, format, v...),
+		}
+	}
+
+	return logMessage{
+		LogLevel: "",
+		Message: "",
 	}
 }
 
 // Warnf ...
-func Warnf(format string, v ...interface{}) {
-	printf(warnSeverity, false, format, v...)
+func Warnf(format string, v ...interface{}) logMessage {
+	return logMessage{
+		LogLevel: "warn",
+		Message: printf(warnSeverity, false, format, v...),
+	}
 }
 
 // Errorf ...
-func Errorf(format string, v ...interface{}) {
-	printf(errorSeverity, false, format, v...)
+func Errorf(format string, v ...interface{}) logMessage {
+	return logMessage{
+		LogLevel: "error",
+		Message: printf(errorSeverity, false, format, v...),
+	}
 }
 
 // TSuccessf ...
-func TSuccessf(format string, v ...interface{}) {
-	printf(successSeverity, true, format, v...)
+func TSuccessf(format string, v ...interface{}) logMessage {
+	return logMessage{
+		LogLevel: "info",
+		Message: printf(successSeverity, true, format, v...),
+	}
 }
 
 // TDonef ...
-func TDonef(format string, v ...interface{}) {
-	TSuccessf(format, v...)
+func TDonef(format string, v ...interface{}) logMessage {
+	return TSuccessf(format, v...)
 }
 
 // TInfof ...
-func TInfof(format string, v ...interface{}) {
-	printf(infoSeverity, true, format, v...)
+func TInfof(format string, v ...interface{}) logMessage {
+	return logMessage{
+		LogLevel: "info",
+		Message: printf(infoSeverity, true, format, v...),
+	}
 }
 
 // TPrintf ...
-func TPrintf(format string, v ...interface{}) {
-	printf(normalSeverity, true, format, v...)
+func TPrintf(format string, v ...interface{}) logMessage {
+	return logMessage{
+		LogLevel: "info",
+		Message: printf(normalSeverity, true, format, v...),
+	}
 }
 
 // TDebugf ...
-func TDebugf(format string, v ...interface{}) {
+func TDebugf(format string, v ...interface{}) logMessage {
 	if enableDebugLog {
-		printf(debugSeverity, true, format, v...)
+		return logMessage{
+			LogLevel: "info",
+			Message: printf(debugSeverity, true, format, v...),
+		}
+	}
+
+	return logMessage{
+		LogLevel: "",
+		Message: "",
 	}
 }
 
 // TWarnf ...
-func TWarnf(format string, v ...interface{}) {
-	printf(warnSeverity, true, format, v...)
+func TWarnf(format string, v ...interface{}) logMessage {
+	return logMessage{
+		LogLevel: "warn",
+		Message: printf(warnSeverity, true, format, v...),
+	}
 }
 
 // TErrorf ...
-func TErrorf(format string, v ...interface{}) {
-	printf(errorSeverity, true, format, v...)
+func TErrorf(format string, v ...interface{}) logMessage {
+	return logMessage{
+		LogLevel: "error",
+		Message: printf(errorSeverity, true, format, v...),
+	}
 }

--- a/log/print.go
+++ b/log/print.go
@@ -15,10 +15,14 @@ func createLogMsg(severity Severity, withTime bool, format string, v ...interfac
 	colorFunc := severityColorFuncMap[severity]
 	message := colorFunc(format, v...)
 	if withTime {
-		message = fmt.Sprintf("%s %s", timestampField(), message)
+		message = prefixCurrentTime(message)
 	}
 
 	return message
+}
+
+func prefixCurrentTime(message string) string {
+	return fmt.Sprintf("%s %s", timestampField(), message)
 }
 
 // Successf ...
@@ -26,7 +30,7 @@ func Successf(format string, v ...interface{}) Message {
 	printf(successSeverity, false, format, v...)
 	return Message{
 		LogLevel: "info",
-		Message: createLogMsg(successSeverity, false, format, v...),
+		Message: fmt.Sprintf(format, v...),
 	}
 }
 
@@ -40,7 +44,7 @@ func Infof(format string, v ...interface{}) Message {
 	printf(infoSeverity, false, format, v...)
 	return Message{
 		LogLevel: "info",
-		Message: createLogMsg(infoSeverity, false, format, v...),
+		Message: fmt.Sprintf(format, v...),
 	}
 }
 
@@ -49,7 +53,7 @@ func Printf(format string, v ...interface{}) Message {
 	printf(normalSeverity, false, format, v...)
 	return Message{
 		LogLevel: "info",
-		Message: createLogMsg(normalSeverity, false, format, v...),
+		Message: fmt.Sprintf(format, v...),
 	}
 }
 
@@ -61,7 +65,7 @@ func Debugf(format string, v ...interface{}) Message {
 
 	return Message{
 		LogLevel: "info",
-		Message: createLogMsg(debugSeverity, false, format, v...),
+		Message: fmt.Sprintf(format, v...),
 	}
 }
 
@@ -70,7 +74,7 @@ func Warnf(format string, v ...interface{}) Message {
 	printf(warnSeverity, false, format, v...)
 	return Message{
 		LogLevel: "warn",
-		Message: createLogMsg(warnSeverity, false, format, v...),
+		Message: fmt.Sprintf(format, v...),
 	}
 }
 
@@ -79,7 +83,7 @@ func Errorf(format string, v ...interface{}) Message {
 	printf(errorSeverity, false, format, v...)
 	return Message{
 		LogLevel: "error",
-		Message: createLogMsg(errorSeverity, false, format, v...),
+		Message: fmt.Sprintf(format, v...),
 	}
 }
 
@@ -88,7 +92,7 @@ func TSuccessf(format string, v ...interface{}) Message {
 	printf(successSeverity, true, format, v...)
 	return Message{
 		LogLevel: "info",
-		Message: createLogMsg(successSeverity, true, format, v...),
+		Message: prefixCurrentTime(fmt.Sprintf(format, v...)),
 	}
 }
 
@@ -102,7 +106,7 @@ func TInfof(format string, v ...interface{}) Message {
 	printf(infoSeverity, true, format, v...)
 	return Message{
 		LogLevel: "info",
-		Message: createLogMsg(infoSeverity, true, format, v...),
+		Message: prefixCurrentTime(fmt.Sprintf(format, v...)),
 	}
 }
 
@@ -111,7 +115,7 @@ func TPrintf(format string, v ...interface{}) Message {
 	printf(normalSeverity, true, format, v...)
 	return Message{
 		LogLevel: "info",
-		Message: createLogMsg(normalSeverity, true, format, v...),
+		Message: prefixCurrentTime(fmt.Sprintf(format, v...)),
 	}
 }
 
@@ -123,7 +127,7 @@ func TDebugf(format string, v ...interface{}) Message {
 
 	return Message{
 		LogLevel: "info",
-		Message: createLogMsg(debugSeverity, true, format, v...),
+		Message: prefixCurrentTime(fmt.Sprintf(format, v...)),
 	}
 }
 
@@ -132,7 +136,7 @@ func TWarnf(format string, v ...interface{}) Message {
 	printf(warnSeverity, true, format, v...)
 	return Message{
 		LogLevel: "warn",
-		Message: createLogMsg(warnSeverity, true, format, v...),
+		Message: prefixCurrentTime(fmt.Sprintf(format, v...)),
 	}
 }
 
@@ -141,6 +145,6 @@ func TErrorf(format string, v ...interface{}) Message {
 	printf(errorSeverity, true, format, v...)
 	return Message{
 		LogLevel: "error",
-		Message: createLogMsg(errorSeverity, true, format, v...),
+		Message: prefixCurrentTime(fmt.Sprintf(format, v...)),
 	}
 }

--- a/log/print.go
+++ b/log/print.go
@@ -26,124 +26,124 @@ func prefixCurrentTime(message string) string {
 }
 
 // Successf ...
-func Successf(format string, v ...interface{}) Message {
+func Successf(format string, v ...interface{}) Entry {
 	printf(successSeverity, false, format, v...)
-	return Message{
+	return Entry{
 		LogLevel: "info",
 		Message: fmt.Sprintf(format, v...),
 	}
 }
 
 // Donef ...
-func Donef(format string, v ...interface{}) Message {
+func Donef(format string, v ...interface{}) Entry {
 	return Successf(format, v...)
 }
 
 // Infof ...
-func Infof(format string, v ...interface{}) Message {
+func Infof(format string, v ...interface{}) Entry {
 	printf(infoSeverity, false, format, v...)
-	return Message{
+	return Entry{
 		LogLevel: "info",
 		Message: fmt.Sprintf(format, v...),
 	}
 }
 
 // Printf ...
-func Printf(format string, v ...interface{}) Message {
+func Printf(format string, v ...interface{}) Entry {
 	printf(normalSeverity, false, format, v...)
-	return Message{
+	return Entry{
 		LogLevel: "info",
 		Message: fmt.Sprintf(format, v...),
 	}
 }
 
 // Debugf ...
-func Debugf(format string, v ...interface{}) Message {
+func Debugf(format string, v ...interface{}) Entry {
 	if enableDebugLog {
 		printf(debugSeverity, false, format, v...)
 	}
 
-	return Message{
+	return Entry{
 		LogLevel: "info",
 		Message: fmt.Sprintf(format, v...),
 	}
 }
 
 // Warnf ...
-func Warnf(format string, v ...interface{}) Message {
+func Warnf(format string, v ...interface{}) Entry {
 	printf(warnSeverity, false, format, v...)
-	return Message{
+	return Entry{
 		LogLevel: "warn",
 		Message: fmt.Sprintf(format, v...),
 	}
 }
 
 // Errorf ...
-func Errorf(format string, v ...interface{}) Message {
+func Errorf(format string, v ...interface{}) Entry {
 	printf(errorSeverity, false, format, v...)
-	return Message{
+	return Entry{
 		LogLevel: "error",
 		Message: fmt.Sprintf(format, v...),
 	}
 }
 
 // TSuccessf ...
-func TSuccessf(format string, v ...interface{}) Message {
+func TSuccessf(format string, v ...interface{}) Entry {
 	printf(successSeverity, true, format, v...)
-	return Message{
+	return Entry{
 		LogLevel: "info",
 		Message: prefixCurrentTime(fmt.Sprintf(format, v...)),
 	}
 }
 
 // TDonef ...
-func TDonef(format string, v ...interface{}) Message {
+func TDonef(format string, v ...interface{}) Entry {
 	return TSuccessf(format, v...)
 }
 
 // TInfof ...
-func TInfof(format string, v ...interface{}) Message {
+func TInfof(format string, v ...interface{}) Entry {
 	printf(infoSeverity, true, format, v...)
-	return Message{
+	return Entry{
 		LogLevel: "info",
 		Message: prefixCurrentTime(fmt.Sprintf(format, v...)),
 	}
 }
 
 // TPrintf ...
-func TPrintf(format string, v ...interface{}) Message {
+func TPrintf(format string, v ...interface{}) Entry {
 	printf(normalSeverity, true, format, v...)
-	return Message{
+	return Entry{
 		LogLevel: "info",
 		Message: prefixCurrentTime(fmt.Sprintf(format, v...)),
 	}
 }
 
 // TDebugf ...
-func TDebugf(format string, v ...interface{}) Message {
+func TDebugf(format string, v ...interface{}) Entry {
 	if enableDebugLog {
 		printf(debugSeverity, true, format, v...)
 	}
 
-	return Message{
+	return Entry{
 		LogLevel: "info",
 		Message: prefixCurrentTime(fmt.Sprintf(format, v...)),
 	}
 }
 
 // TWarnf ...
-func TWarnf(format string, v ...interface{}) Message {
+func TWarnf(format string, v ...interface{}) Entry {
 	printf(warnSeverity, true, format, v...)
-	return Message{
+	return Entry{
 		LogLevel: "warn",
 		Message: prefixCurrentTime(fmt.Sprintf(format, v...)),
 	}
 }
 
 // TErrorf ...
-func TErrorf(format string, v ...interface{}) Message {
+func TErrorf(format string, v ...interface{}) Entry {
 	printf(errorSeverity, true, format, v...)
-	return Message{
+	return Entry{
 		LogLevel: "error",
 		Message: prefixCurrentTime(fmt.Sprintf(format, v...)),
 	}

--- a/log/print.go
+++ b/log/print.go
@@ -19,120 +19,120 @@ func printf(severity Severity, withTime bool, format string, v ...interface{}) s
 }
 
 // Successf ...
-func Successf(format string, v ...interface{}) logMessage {
-	return logMessage{
+func Successf(format string, v ...interface{}) Message {
+	return Message{
 		LogLevel: "info",
 		Message: printf(successSeverity, false, format, v...),
 	}
 }
 
 // Donef ...
-func Donef(format string, v ...interface{}) logMessage {
+func Donef(format string, v ...interface{}) Message {
 	return Successf(format, v...)
 }
 
 // Infof ...
-func Infof(format string, v ...interface{}) logMessage {
-	return logMessage{
+func Infof(format string, v ...interface{}) Message {
+	return Message{
 		LogLevel: "info",
 		Message: printf(infoSeverity, false, format, v...),
 	}
 }
 
 // Printf ...
-func Printf(format string, v ...interface{}) logMessage {
-	return logMessage{
+func Printf(format string, v ...interface{}) Message {
+	return Message{
 		LogLevel: "info",
 		Message: printf(normalSeverity, false, format, v...),
 	}
 }
 
 // Debugf ...
-func Debugf(format string, v ...interface{}) logMessage {
+func Debugf(format string, v ...interface{}) Message {
 	if enableDebugLog {
-		return logMessage{
+		return Message{
 			LogLevel: "info",
 			Message: printf(debugSeverity, false, format, v...),
 		}
 	}
 
-	return logMessage{
+	return Message{
 		LogLevel: "",
 		Message: "",
 	}
 }
 
 // Warnf ...
-func Warnf(format string, v ...interface{}) logMessage {
-	return logMessage{
+func Warnf(format string, v ...interface{}) Message {
+	return Message{
 		LogLevel: "warn",
 		Message: printf(warnSeverity, false, format, v...),
 	}
 }
 
 // Errorf ...
-func Errorf(format string, v ...interface{}) logMessage {
-	return logMessage{
+func Errorf(format string, v ...interface{}) Message {
+	return Message{
 		LogLevel: "error",
 		Message: printf(errorSeverity, false, format, v...),
 	}
 }
 
 // TSuccessf ...
-func TSuccessf(format string, v ...interface{}) logMessage {
-	return logMessage{
+func TSuccessf(format string, v ...interface{}) Message {
+	return Message{
 		LogLevel: "info",
 		Message: printf(successSeverity, true, format, v...),
 	}
 }
 
 // TDonef ...
-func TDonef(format string, v ...interface{}) logMessage {
+func TDonef(format string, v ...interface{}) Message {
 	return TSuccessf(format, v...)
 }
 
 // TInfof ...
-func TInfof(format string, v ...interface{}) logMessage {
-	return logMessage{
+func TInfof(format string, v ...interface{}) Message {
+	return Message{
 		LogLevel: "info",
 		Message: printf(infoSeverity, true, format, v...),
 	}
 }
 
 // TPrintf ...
-func TPrintf(format string, v ...interface{}) logMessage {
-	return logMessage{
+func TPrintf(format string, v ...interface{}) Message {
+	return Message{
 		LogLevel: "info",
 		Message: printf(normalSeverity, true, format, v...),
 	}
 }
 
 // TDebugf ...
-func TDebugf(format string, v ...interface{}) logMessage {
+func TDebugf(format string, v ...interface{}) Message {
 	if enableDebugLog {
-		return logMessage{
+		return Message{
 			LogLevel: "info",
 			Message: printf(debugSeverity, true, format, v...),
 		}
 	}
 
-	return logMessage{
+	return Message{
 		LogLevel: "",
 		Message: "",
 	}
 }
 
 // TWarnf ...
-func TWarnf(format string, v ...interface{}) logMessage {
-	return logMessage{
+func TWarnf(format string, v ...interface{}) Message {
+	return Message{
 		LogLevel: "warn",
 		Message: printf(warnSeverity, true, format, v...),
 	}
 }
 
 // TErrorf ...
-func TErrorf(format string, v ...interface{}) logMessage {
-	return logMessage{
+func TErrorf(format string, v ...interface{}) Message {
+	return Message{
 		LogLevel: "error",
 		Message: printf(errorSeverity, true, format, v...),
 	}

--- a/log/print.go
+++ b/log/print.go
@@ -26,125 +26,75 @@ func prefixCurrentTime(message string) string {
 }
 
 // Successf ...
-func Successf(format string, v ...interface{}) Entry {
+func Successf(format string, v ...interface{}) {
 	printf(successSeverity, false, format, v...)
-	return Entry{
-		LogLevel: "info",
-		Message: fmt.Sprintf(format, v...),
-	}
 }
 
 // Donef ...
-func Donef(format string, v ...interface{}) Entry {
-	return Successf(format, v...)
+func Donef(format string, v ...interface{}) {
+	Successf(format, v...)
 }
 
 // Infof ...
-func Infof(format string, v ...interface{}) Entry {
+func Infof(format string, v ...interface{}) {
 	printf(infoSeverity, false, format, v...)
-	return Entry{
-		LogLevel: "info",
-		Message: fmt.Sprintf(format, v...),
-	}
 }
 
 // Printf ...
-func Printf(format string, v ...interface{}) Entry {
+func Printf(format string, v ...interface{}) {
 	printf(normalSeverity, false, format, v...)
-	return Entry{
-		LogLevel: "info",
-		Message: fmt.Sprintf(format, v...),
-	}
 }
 
 // Debugf ...
-func Debugf(format string, v ...interface{}) Entry {
+func Debugf(format string, v ...interface{}) {
 	if enableDebugLog {
 		printf(debugSeverity, false, format, v...)
-	}
-
-	return Entry{
-		LogLevel: "info",
-		Message: fmt.Sprintf(format, v...),
 	}
 }
 
 // Warnf ...
-func Warnf(format string, v ...interface{}) Entry {
+func Warnf(format string, v ...interface{}) {
 	printf(warnSeverity, false, format, v...)
-	return Entry{
-		LogLevel: "warn",
-		Message: fmt.Sprintf(format, v...),
-	}
 }
 
 // Errorf ...
-func Errorf(format string, v ...interface{}) Entry {
+func Errorf(format string, v ...interface{}) {
 	printf(errorSeverity, false, format, v...)
-	return Entry{
-		LogLevel: "error",
-		Message: fmt.Sprintf(format, v...),
-	}
 }
 
 // TSuccessf ...
-func TSuccessf(format string, v ...interface{}) Entry {
+func TSuccessf(format string, v ...interface{}) {
 	printf(successSeverity, true, format, v...)
-	return Entry{
-		LogLevel: "info",
-		Message: prefixCurrentTime(fmt.Sprintf(format, v...)),
-	}
 }
 
 // TDonef ...
-func TDonef(format string, v ...interface{}) Entry {
-	return TSuccessf(format, v...)
+func TDonef(format string, v ...interface{}) {
+	TSuccessf(format, v...)
 }
 
 // TInfof ...
-func TInfof(format string, v ...interface{}) Entry {
+func TInfof(format string, v ...interface{}) {
 	printf(infoSeverity, true, format, v...)
-	return Entry{
-		LogLevel: "info",
-		Message: prefixCurrentTime(fmt.Sprintf(format, v...)),
-	}
 }
 
 // TPrintf ...
-func TPrintf(format string, v ...interface{}) Entry {
+func TPrintf(format string, v ...interface{}) {
 	printf(normalSeverity, true, format, v...)
-	return Entry{
-		LogLevel: "info",
-		Message: prefixCurrentTime(fmt.Sprintf(format, v...)),
-	}
 }
 
 // TDebugf ...
-func TDebugf(format string, v ...interface{}) Entry {
+func TDebugf(format string, v ...interface{}) {
 	if enableDebugLog {
 		printf(debugSeverity, true, format, v...)
-	}
-
-	return Entry{
-		LogLevel: "info",
-		Message: prefixCurrentTime(fmt.Sprintf(format, v...)),
 	}
 }
 
 // TWarnf ...
-func TWarnf(format string, v ...interface{}) Entry {
+func TWarnf(format string, v ...interface{}) {
 	printf(warnSeverity, true, format, v...)
-	return Entry{
-		LogLevel: "warn",
-		Message: prefixCurrentTime(fmt.Sprintf(format, v...)),
-	}
 }
 
 // TErrorf ...
-func TErrorf(format string, v ...interface{}) Entry {
+func TErrorf(format string, v ...interface{}) {
 	printf(errorSeverity, true, format, v...)
-	return Entry{
-		LogLevel: "error",
-		Message: prefixCurrentTime(fmt.Sprintf(format, v...)),
-	}
 }

--- a/log/print.go
+++ b/log/print.go
@@ -103,7 +103,7 @@ func TErrorf(format string, v ...interface{}) {
 func RInfof(stepID string, tag string, data map[string]interface{}, format string, v ...interface{}) {
 	rprintf("info", stepID, tag, data, format, v...)
 }
-// TWarnf ...
+// RWarnf ...
 func RWarnf(stepID string, tag string, data map[string]interface{}, format string, v ...interface{}) {
 	rprintf("warn", stepID, tag, data, format, v...)
 }

--- a/log/print.go
+++ b/log/print.go
@@ -103,6 +103,7 @@ func TErrorf(format string, v ...interface{}) {
 func RInfof(stepID string, tag string, data map[string]interface{}, format string, v ...interface{}) {
 	rprintf("info", stepID, tag, data, format, v...)
 }
+
 // RWarnf ...
 func RWarnf(stepID string, tag string, data map[string]interface{}, format string, v ...interface{}) {
 	rprintf("warn", stepID, tag, data, format, v...)

--- a/log/print.go
+++ b/log/print.go
@@ -94,7 +94,7 @@ func TSuccessf(format string, v ...interface{}) Message {
 
 // TDonef ...
 func TDonef(format string, v ...interface{}) Message {
-	return TSuccessf(successSeverity, true, format, v...)
+	return TSuccessf(format, v...)
 }
 
 // TInfof ...

--- a/log/print.go
+++ b/log/print.go
@@ -98,3 +98,17 @@ func TWarnf(format string, v ...interface{}) {
 func TErrorf(format string, v ...interface{}) {
 	printf(errorSeverity, true, format, v...)
 }
+
+// RInfof ...
+func RInfof(stepID string, tag string, data map[string]interface{}, format string, v ...interface{}) {
+	rprintf("info", stepID, tag, data, format, v...)
+}
+// TWarnf ...
+func RWarnf(stepID string, tag string, data map[string]interface{}, format string, v ...interface{}) {
+	rprintf("warn", stepID, tag, data, format, v...)
+}
+
+// RErrorf ...
+func RErrorf(stepID string, tag string, data map[string]interface{}, format string, v ...interface{}) {
+	rprintf("error", stepID, tag, data, format, v...)
+}


### PR DESCRIPTION
Internal logging is about sending certain extra information to our analytics server.

This PR simply extends existing `log.Printf`, `log.Infof`, etc... functions to return a log entry object, that can be sent to the analytics server.

API could be better, sending should be the responsibility of a separate service, but as of now, there is no use case for a dedicated service object -- not to mention, that the card description already suggested an API like this.