### PR TITLE
Added funcs.go to templateutil to collect useful functions for Go templates

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1,7 +1,6 @@
-format_version: 5
+format_version: "5"
 default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
-
-
+project_type: ""
 workflows:
   test:
     steps:
@@ -15,7 +14,19 @@ workflows:
             go get -u gopkg.in/yaml.v2
     - go-list:
         inputs:
-        - exclude: "*/vendor/*\n*/pkcs12*"
-    - golint:
-    - errcheck:
-    - go-test:
+        - exclude: |-
+            */vendor/*
+            */pkcs12*
+    - script@1.1.5:
+        title: Debug print $BITRISE_GO_PACKAGES
+        inputs:
+        - content: |-
+            #!/usr/bin/env bash
+            set -e
+
+            echo "=== BITRISE_GO_PACKAGES ==="
+            echo "$BITRISE_GO_PACKAGES"
+            echo "==========================="
+    - golint: {}
+    - errcheck: {}
+    - go-test: {}

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1,4 +1,4 @@
-format_version: "5"
+format_version: "7"
 default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
 project_type: ""
 workflows:
@@ -18,16 +18,6 @@ workflows:
         - exclude: |-
             */vendor/*
             */pkcs12*
-    - script@1.1.5:
-        title: Debug print $BITRISE_GO_PACKAGES
-        inputs:
-        - content: |-
-            #!/usr/bin/env bash
-            set -e
-
-            echo "=== BITRISE_GO_PACKAGES ==="
-            echo "$BITRISE_GO_PACKAGES"
-            echo "==========================="
     - golint: {}
     - errcheck: {}
     - go-test: {}

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -12,6 +12,7 @@ workflows:
             go get -u github.com/stretchr/testify/require
             go get -u golang.org/x/crypto/ssh/terminal
             go get -u gopkg.in/yaml.v2
+            go get -u github.com/pkg/errors
     - go-list:
         inputs:
         - exclude: |-

--- a/templateutil/funcs.go
+++ b/templateutil/funcs.go
@@ -1,0 +1,22 @@
+package templateutil
+
+import (
+	"os"
+
+	"github.com/pkg/errors"
+)
+
+// Getenv returns the specified environment variable
+// or an empty string if the env var key isn't set.
+func Getenv(key string) string {
+	return os.Getenv(key)
+}
+
+// GetenvRequired returns the specified environment variable
+// or an error if the env var isn't set or if its value is empty.
+func GetenvRequired(key string) (string, error) {
+	if val := os.Getenv(key); len(val) > 0 {
+		return val, nil
+	}
+	return "", errors.Errorf("no environment variable value found for key: %s", key)
+}

--- a/templateutil/funcs_test.go
+++ b/templateutil/funcs_test.go
@@ -1,0 +1,50 @@
+package templateutil
+
+import (
+	"testing"
+
+	"github.com/bitrise-io/go-utils/envutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetenv(t *testing.T) {
+	testEnvKey := "KEY_TestGetenv"
+
+	// no env set yet, empty value should be returned
+	require.Equal(t, "", Getenv(testEnvKey))
+
+	// set the env
+	revokeFn, err := envutil.RevokableSetenv(testEnvKey, "env value")
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, revokeFn())
+	}()
+
+	// env set - value should be the env's value
+	require.Equal(t, "env value", Getenv(testEnvKey))
+}
+
+func TestGetenvRequired(t *testing.T) {
+	testEnvKey := "KEY_TestGetenvRequired"
+
+	t.Log("no env set yet, empty value should be returned")
+	{
+		val, err := GetenvRequired(testEnvKey)
+		require.Equal(t, "", val)
+		require.Error(t, err, "no environment variable value found for key: KEY_TestGetenvRequired")
+	}
+
+	// set the env
+	revokeFn, err := envutil.RevokableSetenv(testEnvKey, "env value")
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, revokeFn())
+	}()
+
+	t.Log("env set - value should be the env's value")
+	{
+		val, err := GetenvRequired(testEnvKey)
+		require.NoError(t, err)
+		require.Equal(t, "env value", val)
+	}
+}


### PR DESCRIPTION
Commonly used functions for templates; functions that you can use as `template.FuncMap` functions.

Copied from https://github.com/bitrise-io/gotgen/blob/125332508853e1117c5e8dae9096fa69f0801e7d/cmd/generate.go#L106

I think it'd make sense to collect these functions here, in `go-utils`, so that these can then be used in projects which use `go-utils/templateutil`.

