### PR TITLE
Added RevokableSetenvs and SetenvsForFunction for multi env var handling.

### DIFF
--- a/envutil/envutil.go
+++ b/envutil/envutil.go
@@ -19,10 +19,6 @@ func RevokableSetenv(envKey, envValue string) (func() error, error) {
 func RevokableSetenvs(envs map[string]string) (func() error, error) {
 	origValues := map[string]string{}
 
-	for k := range envs {
-		origValues[k] = os.Getenv(k)
-	}
-
 	revokeFn := func() error {
 		for k, v := range origValues {
 			if err := os.Setenv(k, v); err != nil {
@@ -33,6 +29,8 @@ func RevokableSetenvs(envs map[string]string) (func() error, error) {
 	}
 
 	for k, v := range envs {
+		origValues[k] = os.Getenv(k)
+
 		if err := os.Setenv(k, v); err != nil {
 			return revokeFn, err
 		}

--- a/envutil/envutil.go
+++ b/envutil/envutil.go
@@ -15,9 +15,47 @@ func RevokableSetenv(envKey, envValue string) (func() error, error) {
 	return revokeFn, os.Setenv(envKey, envValue)
 }
 
+// RevokableSetenvs ...
+func RevokableSetenvs(envs map[string]string) (func() error, error) {
+	origValues := map[string]string{}
+
+	for k := range envs {
+		origValues[k] = os.Getenv(k)
+	}
+
+	revokeFn := func() error {
+		for k, v := range origValues {
+			if err := os.Setenv(k, v); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	for k, v := range envs {
+		if err := os.Setenv(k, v); err != nil {
+			return revokeFn, err
+		}
+	}
+
+	return revokeFn, nil
+}
+
 // SetenvForFunction ...
 func SetenvForFunction(envKey, envValue string, fn func()) error {
 	revokeFn, err := RevokableSetenv(envKey, envValue)
+	if err != nil {
+		return err
+	}
+
+	fn()
+
+	return revokeFn()
+}
+
+// SetenvsForFunction ...
+func SetenvsForFunction(envs map[string]string, fn func()) error {
+	revokeFn, err := RevokableSetenvs(envs)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Both work the same way as their singular version but instead of accepting a single env var key & value pair these accept a map of key value pairs and set & revoke all of them.