### PR TITLE
Improve `RunCmdAndReturnExitCode`

### DIFF
--- a/command/command.go
+++ b/command/command.go
@@ -2,14 +2,11 @@ package command
 
 import (
 	"errors"
-	"fmt"
 	"io"
 	"os"
 	"os/exec"
 	"strconv"
 	"strings"
-
-	"github.com/bitrise-io/go-utils/errorutil"
 )
 
 // ----------
@@ -139,18 +136,10 @@ func PrintableCommandArgs(isQuoteFirst bool, fullCommandArgs []string) string {
 }
 
 // RunCmdAndReturnExitCode ...
-func RunCmdAndReturnExitCode(cmd *exec.Cmd) (int, error) {
-	err := cmd.Run()
-	if err != nil {
-		exitCode, castErr := errorutil.CmdExitCodeFromError(err)
-		if castErr != nil {
-			return 1, fmt.Errorf("failed get exit code from error: %s, error: %s", err, castErr)
-		}
-
-		return exitCode, err
-	}
-
-	return 0, nil
+func RunCmdAndReturnExitCode(cmd *exec.Cmd) (exitCode int, err error) {
+	err = cmd.Run()
+	exitCode = cmd.ProcessState.ExitCode()
+	return
 }
 
 // RunCmdAndReturnTrimmedOutput ...

--- a/command/command_test.go
+++ b/command/command_test.go
@@ -1,28 +1,30 @@
-package command
+package command_test
 
 import (
+	"os/exec"
 	"testing"
 
+	"github.com/bitrise-io/go-utils/command"
 	"github.com/stretchr/testify/require"
 )
 
 func TestNewCommandSlice(t *testing.T) {
 	t.Log("it fails if slice empty")
 	{
-		cmd, err := NewFromSlice([]string{})
+		cmd, err := command.NewFromSlice([]string{})
 		require.Error(t, err)
-		require.Equal(t, (*Model)(nil), cmd)
+		require.Equal(t, (*command.Model)(nil), cmd)
 	}
 
 	t.Log("it creates cmd if cmdSlice has 1 element")
 	{
-		_, err := NewFromSlice([]string{"ls"})
+		_, err := command.NewFromSlice([]string{"ls"})
 		require.NoError(t, err)
 	}
 
 	t.Log("it creates cmd if cmdSlice has multiple elements")
 	{
-		_, err := NewFromSlice([]string{"ls", "-a", "-l", "-h"})
+		_, err := command.NewFromSlice([]string{"ls", "-a", "-l", "-h"})
 		require.NoError(t, err)
 	}
 }
@@ -30,20 +32,20 @@ func TestNewCommandSlice(t *testing.T) {
 func TestNewWithParams(t *testing.T) {
 	t.Log("it fails if params empty")
 	{
-		cmd, err := NewWithParams()
+		cmd, err := command.NewWithParams()
 		require.Error(t, err)
-		require.Equal(t, (*Model)(nil), cmd)
+		require.Equal(t, (*command.Model)(nil), cmd)
 	}
 
 	t.Log("it creates cmd if params has 1 element")
 	{
-		_, err := NewWithParams("ls")
+		_, err := command.NewWithParams("ls")
 		require.NoError(t, err)
 	}
 
 	t.Log("it creates cmd if params has multiple elements")
 	{
-		_, err := NewWithParams("ls", "-a", "-l", "-h")
+		_, err := command.NewWithParams("ls", "-a", "-l", "-h")
 		require.NoError(t, err)
 	}
 }

--- a/command/command_test.go
+++ b/command/command_test.go
@@ -61,6 +61,14 @@ func TestRunCmdAndReturnExitCode(t *testing.T) {
 		wantErr      bool
 	}{
 		{
+			name: "invalid command",
+			args: args{
+				cmd: exec.Command(""),
+			},
+			wantExitCode: -1,
+			wantErr:      true,
+		},
+		{
 			name: "env command",
 			args: args{
 				cmd: exec.Command("env"),

--- a/command/command_test.go
+++ b/command/command_test.go
@@ -49,3 +49,52 @@ func TestNewWithParams(t *testing.T) {
 		require.NoError(t, err)
 	}
 }
+
+func TestRunCmdAndReturnExitCode(t *testing.T) {
+	type args struct {
+		cmd *exec.Cmd
+	}
+	tests := []struct {
+		name         string
+		args         args
+		wantExitCode int
+		wantErr      bool
+	}{
+		{
+			name: "env command",
+			args: args{
+				cmd: exec.Command("env"),
+			},
+			wantExitCode: 0,
+			wantErr:      false,
+		},
+		{
+			name: "not existing executable",
+			args: args{
+				cmd: exec.Command("bash", "testdata/not_existing_executable.sh"),
+			},
+			wantExitCode: 127,
+			wantErr:      true,
+		},
+		{
+			name: "exit 42",
+			args: args{
+				cmd: exec.Command("bash", "testdata/exit_42.sh"),
+			},
+			wantExitCode: 42,
+			wantErr:      true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotExitCode, err := command.RunCmdAndReturnExitCode(tt.args.cmd)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("RunCmdAndReturnExitCode() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if gotExitCode != tt.wantExitCode {
+				t.Errorf("RunCmdAndReturnExitCode() = %v, want %v", gotExitCode, tt.wantExitCode)
+			}
+		})
+	}
+}

--- a/command/testdata/exit_42.sh
+++ b/command/testdata/exit_42.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+exit 42

--- a/command/testdata/not_existing_executable.sh
+++ b/command/testdata/not_existing_executable.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+./not_existing_bin

--- a/errorutil/errorutil.go
+++ b/errorutil/errorutil.go
@@ -1,3 +1,6 @@
+// Package errorutil ...
+//
+// Deprecated: This package is redundant, use Go standard library functionalities instead.
 package errorutil
 
 import (
@@ -8,11 +11,15 @@ import (
 )
 
 // IsExitStatusError ...
+//
+// Deprecated: use exec.Cmd.ProcessState.Exited() instead.
 func IsExitStatusError(err error) bool {
 	return IsExitStatusErrorStr(err.Error())
 }
 
 // IsExitStatusErrorStr ...
+//
+// Deprecated: use exec.Cmd.ProcessState.Exited() instead.
 func IsExitStatusErrorStr(errString string) bool {
 	// example exit status error string: exit status 1
 	var rex = regexp.MustCompile(`^exit status [0-9]{1,3}$`)
@@ -20,10 +27,14 @@ func IsExitStatusErrorStr(errString string) bool {
 }
 
 // CmdExitCodeFromError ...
+//
+// Deprecated: use exec.Cmd.ProcessState.ExitCode() instead.
 func CmdExitCodeFromError(err error) (int, error) {
 	cmdExitCode := 0
 	if err != nil {
 		if exitError, ok := err.(*exec.ExitError); ok {
+			exitError.ProcessState.Exited()
+
 			waitStatus, ok := exitError.Sys().(syscall.WaitStatus)
 			if !ok {
 				return 1, errors.New("Failed to cast exit status")

--- a/errorutil/errorutil.go
+++ b/errorutil/errorutil.go
@@ -1,45 +1,32 @@
 // Package errorutil ...
-//
-// Deprecated: This package is redundant, use Go standard library functionalities instead.
 package errorutil
 
 import (
-	"errors"
 	"os/exec"
 	"regexp"
-	"syscall"
 )
 
+func exitCode(err error) int {
+	if exitError, ok := err.(*exec.ExitError); ok {
+		return exitError.ProcessState.ExitCode()
+	}
+	return -1
+}
+
 // IsExitStatusError ...
-//
-// Deprecated: use exec.Cmd.ProcessState.Exited() instead.
 func IsExitStatusError(err error) bool {
-	return IsExitStatusErrorStr(err.Error())
+	return exitCode(err) != -1
 }
 
 // IsExitStatusErrorStr ...
-//
-// Deprecated: use exec.Cmd.ProcessState.Exited() instead.
 func IsExitStatusErrorStr(errString string) bool {
+	// https://golang.org/src/os/exec_posix.go?s=2421:2459#L87
 	// example exit status error string: exit status 1
 	var rex = regexp.MustCompile(`^exit status [0-9]{1,3}$`)
 	return rex.MatchString(errString)
 }
 
 // CmdExitCodeFromError ...
-//
-// Deprecated: use exec.Cmd.ProcessState.ExitCode() instead.
 func CmdExitCodeFromError(err error) (int, error) {
-	cmdExitCode := 0
-	if err != nil {
-		if exitError, ok := err.(*exec.ExitError); ok {
-			waitStatus, ok := exitError.Sys().(syscall.WaitStatus)
-			if !ok {
-				return 1, errors.New("Failed to cast exit status")
-			}
-			cmdExitCode = waitStatus.ExitStatus()
-		}
-		return cmdExitCode, nil
-	}
-	return 0, nil
+	return exitCode(err), err
 }

--- a/errorutil/errorutil.go
+++ b/errorutil/errorutil.go
@@ -33,8 +33,6 @@ func CmdExitCodeFromError(err error) (int, error) {
 	cmdExitCode := 0
 	if err != nil {
 		if exitError, ok := err.(*exec.ExitError); ok {
-			exitError.ProcessState.Exited()
-
 			waitStatus, ok := exitError.Sys().(syscall.WaitStatus)
 			if !ok {
 				return 1, errors.New("Failed to cast exit status")

--- a/errorutil/errorutil_test.go
+++ b/errorutil/errorutil_test.go
@@ -1,42 +1,43 @@
-package errorutil
+package errorutil_test
 
 import (
 	"os/exec"
 	"testing"
 
+	"github.com/bitrise-io/go-utils/errorutil"
 	"github.com/stretchr/testify/require"
 )
 
 func TestIsExitStatusErrorStr(t *testing.T) {
 	// --- Should match ---
-	require.Equal(t, true, IsExitStatusErrorStr("exit status 1"))
-	require.Equal(t, true, IsExitStatusErrorStr("exit status 0"))
-	require.Equal(t, true, IsExitStatusErrorStr("exit status 2"))
-	require.Equal(t, true, IsExitStatusErrorStr("exit status 11"))
-	require.Equal(t, true, IsExitStatusErrorStr("exit status 111"))
-	require.Equal(t, true, IsExitStatusErrorStr("exit status 999"))
+	require.Equal(t, true, errorutil.IsExitStatusErrorStr("exit status 1"))
+	require.Equal(t, true, errorutil.IsExitStatusErrorStr("exit status 0"))
+	require.Equal(t, true, errorutil.IsExitStatusErrorStr("exit status 2"))
+	require.Equal(t, true, errorutil.IsExitStatusErrorStr("exit status 11"))
+	require.Equal(t, true, errorutil.IsExitStatusErrorStr("exit status 111"))
+	require.Equal(t, true, errorutil.IsExitStatusErrorStr("exit status 999"))
 
 	// --- Should not match ---
-	require.Equal(t, false, IsExitStatusErrorStr("xit status 1"))
-	require.Equal(t, false, IsExitStatusErrorStr("status 1"))
-	require.Equal(t, false, IsExitStatusErrorStr("exit status "))
-	require.Equal(t, false, IsExitStatusErrorStr("exit status"))
-	require.Equal(t, false, IsExitStatusErrorStr("exit status 2112"))
-	require.Equal(t, false, IsExitStatusErrorStr("exit status 21121"))
+	require.Equal(t, false, errorutil.IsExitStatusErrorStr("xit status 1"))
+	require.Equal(t, false, errorutil.IsExitStatusErrorStr("status 1"))
+	require.Equal(t, false, errorutil.IsExitStatusErrorStr("exit status "))
+	require.Equal(t, false, errorutil.IsExitStatusErrorStr("exit status"))
+	require.Equal(t, false, errorutil.IsExitStatusErrorStr("exit status 2112"))
+	require.Equal(t, false, errorutil.IsExitStatusErrorStr("exit status 21121"))
 
 	// prefixed
-	require.Equal(t, false, IsExitStatusErrorStr(".exit status 1"))
-	require.Equal(t, false, IsExitStatusErrorStr(" exit status 1"))
-	require.Equal(t, false, IsExitStatusErrorStr("error: exit status 1"))
+	require.Equal(t, false, errorutil.IsExitStatusErrorStr(".exit status 1"))
+	require.Equal(t, false, errorutil.IsExitStatusErrorStr(" exit status 1"))
+	require.Equal(t, false, errorutil.IsExitStatusErrorStr("error: exit status 1"))
 	// postfixed
-	require.Equal(t, false, IsExitStatusErrorStr("exit status 1."))
-	require.Equal(t, false, IsExitStatusErrorStr("exit status 1 "))
-	require.Equal(t, false, IsExitStatusErrorStr("exit status 1 - something else"))
-	require.Equal(t, false, IsExitStatusErrorStr("exit status 1 2"))
+	require.Equal(t, false, errorutil.IsExitStatusErrorStr("exit status 1."))
+	require.Equal(t, false, errorutil.IsExitStatusErrorStr("exit status 1 "))
+	require.Equal(t, false, errorutil.IsExitStatusErrorStr("exit status 1 - something else"))
+	require.Equal(t, false, errorutil.IsExitStatusErrorStr("exit status 1 2"))
 
 	// other
-	require.Equal(t, false, IsExitStatusErrorStr("-exit status 211-"))
-	require.Equal(t, false, IsExitStatusErrorStr("something else: exit status 1"))
+	require.Equal(t, false, errorutil.IsExitStatusErrorStr("-exit status 211-"))
+	require.Equal(t, false, errorutil.IsExitStatusErrorStr("something else: exit status 1"))
 }
 
 func TestCmdExitCodeFromError(t *testing.T) {
@@ -72,7 +73,7 @@ func TestCmdExitCodeFromError(t *testing.T) {
 			err := tt.cmd.Run()
 
 			// Act
-			got, err := CmdExitCodeFromError(err)
+			got, err := errorutil.CmdExitCodeFromError(err)
 
 			// Assert
 			require.Equal(t, tt.want, got)
@@ -104,7 +105,7 @@ func TestIsExitStatusError(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := IsExitStatusError(tt.err)
+			got := errorutil.IsExitStatusError(tt.err)
 			require.Equal(t, tt.want, got)
 		})
 	}

--- a/errorutil/errorutil_test.go
+++ b/errorutil/errorutil_test.go
@@ -1,6 +1,7 @@
 package errorutil
 
 import (
+	"os/exec"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -36,4 +37,73 @@ func TestIsExitStatusErrorStr(t *testing.T) {
 	// other
 	require.Equal(t, false, IsExitStatusErrorStr("-exit status 211-"))
 	require.Equal(t, false, IsExitStatusErrorStr("something else: exit status 1"))
+}
+
+func TestCmdExitCodeFromError(t *testing.T) {
+	// Arrange
+	tests := []struct {
+		name string
+		cmd  *exec.Cmd
+		want int
+	}{
+		{
+			name: "env command",
+			cmd:  exec.Command("env"),
+			want: 0,
+		},
+		{
+			name: "not existing executable",
+			cmd:  exec.Command("bash", "testdata/not_existing_executable.sh"),
+			want: 127,
+		},
+		{
+			name: "exit 42",
+			cmd:  exec.Command("bash", "testdata/exit_42.sh"),
+			want: 42,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.cmd.Run()
+			want := tt.cmd.ProcessState.ExitCode()
+			if tt.want != want {
+				t.Errorf("Invalid test expectation: tt.cmd.ProcessState.ExitCode() = %v, want %v", want, tt.want)
+			}
+
+			// Act
+			got, err := CmdExitCodeFromError(err)
+
+			// Assert
+			if got != want {
+				t.Errorf("CmdExitCodeFromError() = %v, want %v", got, want)
+			}
+		})
+	}
+}
+
+func TestIsExitStatusError(t *testing.T) {
+	tests := []struct {
+		name string
+		cmd  *exec.Cmd
+		want bool
+	}{
+		{
+			name: "exit 42",
+			cmd:  exec.Command("bash", "testdata/exit_42.sh"),
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.cmd.Run()
+			want := tt.cmd.ProcessState.Exited()
+			if tt.want != want {
+				t.Errorf("Invalid test expectation: tt.cmd.ProcessState.Exited() = %v, want %v", want, tt.want)
+			}
+
+			if got := IsExitStatusError(err); got != tt.want {
+				t.Errorf("IsExitStatusError() = %v, want %v", got, tt.want)
+			}
+		})
+	}
 }

--- a/errorutil/testdata/exit_42.sh
+++ b/errorutil/testdata/exit_42.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+exit 42

--- a/errorutil/testdata/not_existing_executable.sh
+++ b/errorutil/testdata/not_existing_executable.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+./not_existing_bin


### PR DESCRIPTION
**`command/RunCmdAndReturnExitCode` changes:**

`errorutil.CmdExitCodeFromError(err)` does the same as `cmd.ProcessState.ExitCode()`, except CmdExitCodeFromError falls back to exist status 0 or 1 in case of an issue, while Go standard library uses `-1`.

more info:
- https://golang.org/src/os/exec/exec.go?s=13923:13957#L467
- https://golang.org/src/os/exec_posix.go?s=2421:2459#L87

~~**`errorutil` deprecated:**~~

~~All functionalities can be solved by the standard library functions, see deprecation notes and new tests.~~

**`errorutil` changes:**

Use Go standard library functionalities.



