### PR TITLE
Support extra arguments for SubmoduleUpdate

### DIFF
--- a/command/git/commands.go
+++ b/command/git/commands.go
@@ -62,9 +62,11 @@ func (g *Git) Clean(options ...string) *command.Model {
 }
 
 // SubmoduleUpdate updates the registered submodules.
-func (g *Git) SubmoduleUpdate(opts ...string) *command.Model {
+func (g *Git) SubmoduleUpdate(shallowCheckout bool) *command.Model {
 	args := []string{"submodule", "update", "--init", "--recursive"}
-	args = append(args, opts...)
+	if shallowCheckout {
+		args = append(args, "--depth=1")
+	}
 	return g.command(args...)
 }
 

--- a/command/git/commands.go
+++ b/command/git/commands.go
@@ -62,8 +62,10 @@ func (g *Git) Clean(options ...string) *command.Model {
 }
 
 // SubmoduleUpdate updates the registered submodules.
-func (g *Git) SubmoduleUpdate() *command.Model {
-	return g.command("submodule", "update", "--init", "--recursive")
+func (g *Git) SubmoduleUpdate(opts ...string) *command.Model {
+	args := []string{"submodule", "update", "--init", "--recursive"}
+	args = append(args, opts...)
+	return g.command(args...)
 }
 
 // SubmoduleForeach evaluates an arbitrary git command in each checked out


### PR DESCRIPTION
### Description
Add `opts` argument to `SubmoduleUpdate` function on gitcommand to support extra args from caller.