### PR TITLE
Use --jobs flag on fetch and submodule update commands

### DIFF
--- a/command/git/commands.go
+++ b/command/git/commands.go
@@ -62,8 +62,9 @@ func (g *Git) Clean(options ...string) *command.Model {
 }
 
 // SubmoduleUpdate updates the registered submodules.
-func (g *Git) SubmoduleUpdate(shallowCheckout bool) *command.Model {
-	args := []string{"submodule", "update", "--init", "--recursive", "--jobs=10"}
+func (g *Git) SubmoduleUpdate(shallowCheckout bool, opts ...string) *command.Model {
+	args := []string{"submodule", "update", "--init", "--recursive"}
+	args = append(args, opts...)
 	if shallowCheckout {
 		args = append(args, "--depth=1")
 	}

--- a/command/git/commands.go
+++ b/command/git/commands.go
@@ -31,7 +31,7 @@ func (g *Git) RemoteAdd(name, url string) *command.Model {
 
 // Fetch downloads objects and refs from another repository.
 func (g *Git) Fetch(opts ...string) *command.Model {
-	args := []string{"fetch", "--jobs=10"}
+	args := []string{"fetch"}
 	args = append(args, opts...)
 	return g.command(args...)
 }

--- a/command/git/commands.go
+++ b/command/git/commands.go
@@ -63,7 +63,7 @@ func (g *Git) Clean(options ...string) *command.Model {
 
 // SubmoduleUpdate updates the registered submodules.
 func (g *Git) SubmoduleUpdate(shallowCheckout bool) *command.Model {
-	args := []string{"submodule", "update", "--init", "--recursive", "--jobs"}
+	args := []string{"submodule", "update", "--init", "--recursive", "--jobs=10"}
 	if shallowCheckout {
 		args = append(args, "--depth=1")
 	}

--- a/command/git/commands.go
+++ b/command/git/commands.go
@@ -31,7 +31,7 @@ func (g *Git) RemoteAdd(name, url string) *command.Model {
 
 // Fetch downloads objects and refs from another repository.
 func (g *Git) Fetch(opts ...string) *command.Model {
-	args := []string{"fetch"}
+	args := []string{"fetch", "--jobs=10"}
 	args = append(args, opts...)
 	return g.command(args...)
 }
@@ -63,7 +63,7 @@ func (g *Git) Clean(options ...string) *command.Model {
 
 // SubmoduleUpdate updates the registered submodules.
 func (g *Git) SubmoduleUpdate(shallowCheckout bool) *command.Model {
-	args := []string{"submodule", "update", "--init", "--recursive"}
+	args := []string{"submodule", "update", "--init", "--recursive", "--jobs"}
 	if shallowCheckout {
 		args = append(args, "--depth=1")
 	}


### PR DESCRIPTION
https://bitrise.atlassian.net/browse/STEP-680

### Description
`--jobs` flag with the default value of `10` added to the `git fetch` and `git submodule update` commands, based on [this](https://bitrise.atlassian.net/wiki/spaces/STEP/pages/1325236987/Git+Clone+Step+--jobs+flag+investigation) investigation.