### PR TITLE
Add sparse-checkout commands to Git

### DIFF
--- a/command/git/commands.go
+++ b/command/git/commands.go
@@ -145,12 +145,18 @@ func (g *Git) Config(key string, value string) *command.Model {
 	return g.command("config", key, value)
 }
 
-func (g *Git) SparseCheckoutInit() *command.Model {
-	return g.command("sparse-checkout", "init", "--cone")
+// SparseCheckoutInit initializes the sparse-checkout config file.
+func (g *Git) SparseCheckoutInit(cone bool) *command.Model {
+	args := []string{"sparse-checkout", "init"}
+	if cone {
+		args = append(args, "--cone")
+	}
+	return g.command(args...)
 }
 
-func (g *Git) SparseCheckoutSet(folders ...string) *command.Model {
+// SparseCheckoutSet writes the provided patterns to the sparse-checkout config file.
+func (g *Git) SparseCheckoutSet(opts ...string) *command.Model {
 	args := []string{"sparse-checkout", "set"}
-	args = append(args, folders...)
+	args = append(args, opts...)
 	return g.command(args...)
 }

--- a/command/git/commands.go
+++ b/command/git/commands.go
@@ -144,3 +144,13 @@ func (g *Git) Status(opts ...string) *command.Model {
 func (g *Git) Config(key string, value string) *command.Model {
 	return g.command("config", key, value)
 }
+
+func (g *Git) SparseCheckoutInit() *command.Model {
+	return g.command("sparse-checkout", "init", "--cone")
+}
+
+func (g *Git) SparseCheckoutSet(folders ...string) *command.Model {
+	args := []string{"sparse-checkout", "set"}
+	args = append(args, folders...)
+	return g.command(args...)
+}

--- a/command/git/commands_test.go
+++ b/command/git/commands_test.go
@@ -1,0 +1,40 @@
+package git
+
+import (
+	"testing"
+
+	"github.com/bitrise-io/go-utils/command"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGitCommands(t *testing.T) {
+	type testCase struct {
+		command *command.Model
+		want    string
+	}
+
+	testCases := []testCase{
+		// SparseCheckout
+		{
+			command: (&Git{}).SparseCheckoutInit(),
+			want:    `git "sparse-checkout" "init" "--cone"`,
+		},
+		{
+			command: (&Git{}).SparseCheckoutSet("client/android"),
+			want:    `git "sparse-checkout" "set" "client/android"`,
+		},
+		{
+			command: (&Git{}).SparseCheckoutSet("client/android", "client/ios"),
+			want:    `git "sparse-checkout" "set" "client/android" "client/ios"`,
+		},
+	}
+
+	for _, testCase := range testCases {
+		assertPrintableCommandArgs(t, testCase.want, testCase.command)
+	}
+}
+
+func assertPrintableCommandArgs(t *testing.T, expectedArgs string, gitCommand *command.Model) {
+	actualArgs := gitCommand.PrintableCommandArgs()
+	assert.Equal(t, expectedArgs, actualArgs)
+}

--- a/command/git/commands_test.go
+++ b/command/git/commands_test.go
@@ -16,7 +16,11 @@ func TestGitCommands(t *testing.T) {
 	testCases := []testCase{
 		// SparseCheckout
 		{
-			command: (&Git{}).SparseCheckoutInit(),
+			command: (&Git{}).SparseCheckoutInit(false),
+			want:    `git "sparse-checkout" "init"`,
+		},
+		{
+			command: (&Git{}).SparseCheckoutInit(true),
 			want:    `git "sparse-checkout" "init" "--cone"`,
 		},
 		{


### PR DESCRIPTION
### Description

Add sparse-checkout commands to Git.

More info in [git-sparse-checkout](https://git-scm.com/docs/git-sparse-checkout)

### Changes
- Adding `SparseCheckoutInit` and `SparseCheckoutSet` functions to `git.commands`.
- Added tests.