### PR TITLE
Remove dedicated `shallowCheckout` parameter

### DIFF
--- a/command/git/commands.go
+++ b/command/git/commands.go
@@ -62,12 +62,9 @@ func (g *Git) Clean(options ...string) *command.Model {
 }
 
 // SubmoduleUpdate updates the registered submodules.
-func (g *Git) SubmoduleUpdate(shallowCheckout bool, opts ...string) *command.Model {
+func (g *Git) SubmoduleUpdate(opts ...string) *command.Model {
 	args := []string{"submodule", "update", "--init", "--recursive"}
 	args = append(args, opts...)
-	if shallowCheckout {
-		args = append(args, "--depth=1")
-	}
 	return g.command(args...)
 }
 


### PR DESCRIPTION
https://bitrise.atlassian.net/browse/STEP-808

### Context
Our [measurements](https://bitrise.atlassian.net/wiki/spaces/STEP/pages/1459683606/Git+clone+performance+degradation+investigation) suggested that the `--depth=1` flag applied to the `submodule update` by default did not result in a general performance improvement, so the dedicated option is going to be replaced with a configurable `depth` option instead, which might be passed via the `opts` parameter.

### Changes
- The dedicated `shallowCheckout` option of the `submodule update` removed.