### PR TITLE
Remove CaseInsensitiveContains and CaseInsensitiveCompare.

### DIFF
--- a/stringutil/stringutil.go
+++ b/stringutil/stringutil.go
@@ -19,18 +19,6 @@ func ReadFirstLine(s string, isIgnoreLeadingEmptyLines bool) string {
 	return firstLine
 }
 
-// CaseInsensitiveEquals ...
-func CaseInsensitiveEquals(a, b string) bool {
-	a, b = strings.ToLower(a), strings.ToLower(b)
-	return a == b
-}
-
-// CaseInsensitiveContains ...
-func CaseInsensitiveContains(s, substr string) bool {
-	s, substr = strings.ToLower(s), strings.ToLower(substr)
-	return strings.Contains(s, substr)
-}
-
 // MaxLastChars returns the last maxCharCount characters,
 //  or in case maxCharCount is more than or equal to the string's length
 //  it'll just return the whole string.

--- a/stringutil/stringutil_test.go
+++ b/stringutil/stringutil_test.go
@@ -68,52 +68,6 @@ second line`, true)
 	}
 }
 
-func TestCaseInsensitiveEquals(t *testing.T) {
-	var emptyStr string // ""
-
-	require.Equal(t, true, CaseInsensitiveEquals(emptyStr, emptyStr))
-	require.Equal(t, true, CaseInsensitiveEquals("", ""))
-
-	require.Equal(t, true, CaseInsensitiveEquals(emptyStr, ""))
-	require.Equal(t, true, CaseInsensitiveEquals("", emptyStr))
-
-	require.Equal(t, false, CaseInsensitiveEquals(emptyStr, "a"))
-	require.Equal(t, false, CaseInsensitiveEquals("a", emptyStr))
-
-	require.Equal(t, true, CaseInsensitiveEquals("a", "a"))
-	require.Equal(t, true, CaseInsensitiveEquals("a", "A"))
-
-	require.Equal(t, true, CaseInsensitiveEquals("ab", "Ab"))
-
-	require.Equal(t, false, CaseInsensitiveEquals("ab", "ba"))
-	require.Equal(t, false, CaseInsensitiveEquals("ab", "Ba"))
-}
-
-func TestCaseInsensitiveContains(t *testing.T) {
-	var emptyStr string // ""
-
-	require.Equal(t, true, CaseInsensitiveContains(emptyStr, emptyStr))
-	require.Equal(t, true, CaseInsensitiveContains("", ""))
-
-	require.Equal(t, true, CaseInsensitiveContains(emptyStr, ""))
-	require.Equal(t, true, CaseInsensitiveContains("", emptyStr))
-
-	require.Equal(t, false, CaseInsensitiveContains(emptyStr, "a"))
-	require.Equal(t, true, CaseInsensitiveContains("a", emptyStr))
-
-	require.Equal(t, true, CaseInsensitiveContains("a", "a"))
-	require.Equal(t, true, CaseInsensitiveContains("A", "a"))
-
-	require.Equal(t, true, CaseInsensitiveContains("abc", "a"))
-	require.Equal(t, true, CaseInsensitiveContains("abc", "B"))
-	require.Equal(t, true, CaseInsensitiveContains("abc", "BC"))
-	require.Equal(t, true, CaseInsensitiveContains("abc", "ABC"))
-
-	require.Equal(t, false, CaseInsensitiveContains("abc", "d"))
-	require.Equal(t, false, CaseInsensitiveContains("abc", "ba"))
-	require.Equal(t, false, CaseInsensitiveContains("abc", "BAC"))
-}
-
 func TestGenericTrim(t *testing.T) {
 	require.Equal(t, "", genericTrim("", 4, false, false))
 	require.Equal(t, "", genericTrim("", 4, false, true))


### PR DESCRIPTION
### Context

Remove CaseInsensitiveContains and CaseInsensitiveCompare.

Use strings.EqualFold instead (https://golang.org/pkg/strings/#EqualFold) of CaseInsensitiveCompare.

For CaseInsensitiveContains there is no ready made replacement.

<!-- Please link the issue that the PR fixes.
Resolves: #GITHUB_ISSUE_ID or https://link_to_the_issue_on_discuss.
-->

### Changes

<!-- 
- `blahblah` is called with `hhhh` instead of `oooooo`
- `FFFFF` now returns an `error` for better error handling
- Renamed symbols in `pppppp` to increase readability
-->

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

<!-- Please list decisions that were made for this change. -->