### PR TITLE
Adding additional options parameter to git log command

### DIFF
--- a/command/git/commands.go
+++ b/command/git/commands.go
@@ -104,8 +104,11 @@ func (g *Git) Apply(patch string) *command.Model {
 }
 
 // Log shows the commit logs. The format parameter controls what is shown and how.
-func (g *Git) Log(format string) *command.Model {
-	return g.command("log", "-1", "--format="+format)
+// Revision range can be optionally specified using the opts parameter.
+func (g *Git) Log(format string, opts ...string) *command.Model {
+	args := []string{"log", "-1", "--format=" + format}
+	args = append(args, opts...)
+	return g.command(args...)
 }
 
 // RevList lists commit objects in reverse chronological order.

--- a/command/git/commands_test.go
+++ b/command/git/commands_test.go
@@ -31,6 +31,11 @@ func TestGitCommands(t *testing.T) {
 			command: (&Git{}).SparseCheckoutSet("client/android", "client/ios"),
 			want:    `git "sparse-checkout" "set" "client/android" "client/ios"`,
 		},
+		// Log
+		{
+			command: (&Git{}).Log("%H", "refs/head/hcnarb"),
+			want:    `git "log" "-1" "--format=%H" "refs/head/hcnarb"`,
+		},
 	}
 
 	for _, testCase := range testCases {


### PR DESCRIPTION
### Context

Added option to specify revision for the git log command.

Resolves: https://bitrise.atlassian.net/browse/STEP-1135

### Changes

- Added additional options paramter to git log command.

