### PR TITLE
Refresh command package mocks.

### DIFF
--- a/command/mocks/Command.go
+++ b/command/mocks/Command.go
@@ -99,3 +99,31 @@ func (_m *Command) RunAndReturnTrimmedOutput() (string, error) {
 
 	return r0, r1
 }
+
+// Start provides a mock function with given fields:
+func (_m *Command) Start() error {
+	ret := _m.Called()
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func() error); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// Wait provides a mock function with given fields:
+func (_m *Command) Wait() error {
+	ret := _m.Called()
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func() error); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}


### PR DESCRIPTION
### Context

This PR makes up for the forgotten mocks package regeneration after [modifying the command package](https://github.com/bitrise-io/go-utils/pull/139).

### Changes

<!-- 
- `blahblah` is called with `hhhh` instead of `oooooo`
- `FFFFF` now returns an `error` for better error handling
- Renamed symbols in `pppppp` to increase readability
-->

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

<!-- Please list decisions that were made for this change. -->
