### PR TITLE
Adds support for downloading file contents

### DIFF
--- a/filedownloader/filedownloader.go
+++ b/filedownloader/filedownloader.go
@@ -1,6 +1,7 @@
 package filedownloader
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"net/http"
@@ -14,19 +15,19 @@ type HTTPClient interface {
 	Get(source string) (*http.Response, error)
 }
 
-// HTTPFileDownloader ...
-type HTTPFileDownloader struct {
+// DefaultFileDownloader ...
+type DefaultFileDownloader struct {
 	client HTTPClient
 }
 
 // New ...
-func New(client HTTPClient) HTTPFileDownloader {
-	return HTTPFileDownloader{client}
+func New(client HTTPClient) DefaultFileDownloader {
+	return DefaultFileDownloader{client}
 }
 
 // GetWithFallback downloads a file from a given source. Provided destination should be a file that does not exist.
 // You can specify fallback sources which will be used in order if downloading fails from either source.
-func (downloader HTTPFileDownloader) GetWithFallback(destination, source string, fallbackSources ...string) error {
+func (downloader DefaultFileDownloader) GetWithFallback(destination, source string, fallbackSources ...string) error {
 	sources := append([]string{source}, fallbackSources...)
 	for _, source := range sources {
 		err := downloader.Get(destination, source)
@@ -41,9 +42,36 @@ func (downloader HTTPFileDownloader) GetWithFallback(destination, source string,
 }
 
 // Get downloads a file from a given source. Provided destination should be a file that does not exist.
-func (downloader HTTPFileDownloader) Get(destination, source string) error {
+func (downloader DefaultFileDownloader) Get(destination, source string) error {
+	f, err := os.Create(destination)
+	if err != nil {
+		return err
+	}
 
-	resp, err := downloader.client.Get(source)
+	defer func() {
+		if err := f.Close(); err != nil {
+			log.Errorf("Failed to close file, error: %s", err)
+		}
+	}()
+
+	return download(downloader.client, source, f)
+}
+
+func (downloader DefaultFileDownloader) GetRemoteContents(URL string) ([]byte, error) {
+	var contents []byte
+	if err := download(downloader.client, URL, bytes.NewBuffer(contents)); err != nil {
+		return nil, err
+	}
+
+	return contents, nil
+}
+
+func (downloader DefaultFileDownloader) ReadLocalFile(path string) ([]byte, error) {
+	return os.ReadFile(path)
+}
+
+func download(client HTTPClient, source string, destination io.Writer) error {
+	resp, err := client.Get(source)
 	if err != nil {
 		return err
 	}
@@ -58,18 +86,7 @@ func (downloader HTTPFileDownloader) Get(destination, source string) error {
 		}
 	}()
 
-	f, err := os.Create(destination)
-	if err != nil {
-		return err
-	}
-
-	defer func() {
-		if err := f.Close(); err != nil {
-			log.Errorf("Failed to close file, error: %s", err)
-		}
-	}()
-
-	if _, err = io.Copy(f, resp.Body); err != nil {
+	if _, err = io.Copy(destination, resp.Body); err != nil {
 		return err
 	}
 

--- a/filedownloader/filedownloader.go
+++ b/filedownloader/filedownloader.go
@@ -57,6 +57,7 @@ func (downloader DefaultFileDownloader) Get(destination, source string) error {
 	return download(downloader.client, source, f)
 }
 
+// GetRemoteContents fetches a remote URL contents
 func (downloader DefaultFileDownloader) GetRemoteContents(URL string) ([]byte, error) {
 	var contents []byte
 	if err := download(downloader.client, URL, bytes.NewBuffer(contents)); err != nil {
@@ -66,6 +67,7 @@ func (downloader DefaultFileDownloader) GetRemoteContents(URL string) ([]byte, e
 	return contents, nil
 }
 
+// ReadLocalFile returns a local file contents
 func (downloader DefaultFileDownloader) ReadLocalFile(path string) ([]byte, error) {
 	return os.ReadFile(path)
 }

--- a/filedownloader/filedownloader.go
+++ b/filedownloader/filedownloader.go
@@ -16,22 +16,22 @@ type HTTPClient interface {
 	Do(req *http.Request) (*http.Response, error)
 }
 
-// DefaultFileDownloader ...
-type DefaultFileDownloader struct {
+// FileDownloader ...
+type FileDownloader struct {
 	client  HTTPClient
 	context context.Context
 }
 
 // New ...
-func New(client HTTPClient) DefaultFileDownloader {
-	return DefaultFileDownloader{
+func New(client HTTPClient) FileDownloader {
+	return FileDownloader{
 		client: client,
 	}
 }
 
 // NewWithContext ...
-func NewWithContext(context context.Context, client HTTPClient) DefaultFileDownloader {
-	return DefaultFileDownloader{
+func NewWithContext(context context.Context, client HTTPClient) FileDownloader {
+	return FileDownloader{
 		client:  client,
 		context: context,
 	}
@@ -39,7 +39,7 @@ func NewWithContext(context context.Context, client HTTPClient) DefaultFileDownl
 
 // GetWithFallback downloads a file from a given source. Provided destination should be a file that does not exist.
 // You can specify fallback sources which will be used in order if downloading fails from either source.
-func (downloader DefaultFileDownloader) GetWithFallback(destination, source string, fallbackSources ...string) error {
+func (downloader FileDownloader) GetWithFallback(destination, source string, fallbackSources ...string) error {
 	sources := append([]string{source}, fallbackSources...)
 	for _, source := range sources {
 		err := downloader.Get(destination, source)
@@ -55,7 +55,7 @@ func (downloader DefaultFileDownloader) GetWithFallback(destination, source stri
 }
 
 // Get downloads a file from a given source. Provided destination should be a file that does not exist.
-func (downloader DefaultFileDownloader) Get(destination, source string) error {
+func (downloader FileDownloader) Get(destination, source string) error {
 	f, err := os.Create(destination)
 	if err != nil {
 		return err
@@ -71,7 +71,7 @@ func (downloader DefaultFileDownloader) Get(destination, source string) error {
 }
 
 // GetRemoteContents fetches a remote URL contents
-func (downloader DefaultFileDownloader) GetRemoteContents(URL string) ([]byte, error) {
+func (downloader FileDownloader) GetRemoteContents(URL string) ([]byte, error) {
 	var contents []byte
 	if err := download(downloader.context, downloader.client, URL, bytes.NewBuffer(contents)); err != nil {
 		return nil, err
@@ -81,7 +81,7 @@ func (downloader DefaultFileDownloader) GetRemoteContents(URL string) ([]byte, e
 }
 
 // ReadLocalFile returns a local file contents
-func (downloader DefaultFileDownloader) ReadLocalFile(path string) ([]byte, error) {
+func (downloader FileDownloader) ReadLocalFile(path string) ([]byte, error) {
 	return os.ReadFile(path)
 }
 

--- a/filedownloader/filedownloader_test.go
+++ b/filedownloader/filedownloader_test.go
@@ -202,8 +202,8 @@ type mockResponse struct {
 	response http.Response
 }
 
-func givenFileDownloader(client HTTPClient) DefaultFileDownloader {
-	return DefaultFileDownloader{
+func givenFileDownloader(client HTTPClient) FileDownloader {
+	return FileDownloader{
 		client: client,
 	}
 }


### PR DESCRIPTION
## Changes
- FileDownlaoder now implements GetRemoteContents and ReadLocalFile. Both return a byte slice.
- Added NewWithContext so a context can be passed in, to be used to timeout HTTP Do call.
- Get and  GetRemoteContents both call *download()*, the HTTP call now uses Do instead of Get, so a context can be set.