### PR TITLE
[MOB-190] Add possibility of aborting a retry loop

### DIFF
--- a/retry/retry.go
+++ b/retry/retry.go
@@ -8,6 +8,9 @@ import (
 // Action ...
 type Action func(attempt uint) error
 
+// AbortableAction ...
+type AbortableAction func(attempt uint) (error, bool)
+
 // Model ...
 type Model struct {
 	retry    uint
@@ -38,19 +41,37 @@ func (Model *Model) Wait(waitTime time.Duration) *Model {
 	return Model
 }
 
-// Try ...
+// Try continues executing the supplied action while this action parameter returns an error and the configured
+// number of times has not been reached. Otherwise, it stops and returns the last received error.
 func (Model Model) Try(action Action) error {
+	return Model.TryWithAbort(func(attempt uint) (error, bool) {
+		return action(attempt), false
+	})
+}
+
+// TryWithAbort continues executing the supplied action while this action parameter returns an error, a false bool
+// value and the configured number of times has not been reached. Returning a true value from the action aborts the
+// retry loop.
+//
+// Good for retrying actions which can return a mix of retryable and non-retryable failures.
+func (Model Model) TryWithAbort(action AbortableAction) error {
 	if action == nil {
 		return fmt.Errorf("no action specified")
 	}
 
 	var err error
+	var shouldAbort bool
+
 	for attempt := uint(0); (0 == attempt || nil != err) && attempt <= Model.retry; attempt++ {
 		if attempt > 0 && Model.waitTime > 0 {
 			time.Sleep(Model.waitTime)
 		}
 
-		err = action(attempt)
+		err, shouldAbort = action(attempt)
+
+		if shouldAbort {
+			break
+		}
 	}
 
 	return err


### PR DESCRIPTION
A new use case came up for the retry mechanism where we want to apply retry selectively for specific errors. Such an example is where an intermittent network failure took place. We want to only retry network errors from which we can recover and not for example build errors. 

This addition introduces a new method where a bool value needs to be returned together with the error instance which indicates if the retry should be aborted or not. 