### PR TITLE
[MOB-257] Add multi folder zipping support

### DIFF
--- a/ziputil/ziputil.go
+++ b/ziputil/ziputil.go
@@ -3,6 +3,8 @@ package ziputil
 import (
 	"fmt"
 	"github.com/bitrise-io/go-utils/env"
+	"log"
+	"os"
 	"path/filepath"
 
 	"github.com/bitrise-io/go-utils/command"
@@ -18,21 +20,57 @@ func ZipDir(sourceDirPth, destinationZipPth string, isContentOnly bool) error {
 	}
 
 	workDir := filepath.Dir(sourceDirPth)
+	zipTarget := filepath.Base(sourceDirPth)
+
 	if isContentOnly {
 		workDir = sourceDirPth
-	}
-
-	zipTarget := filepath.Base(sourceDirPth)
-	if isContentOnly {
 		zipTarget = "."
 	}
+
+	return internalZipDir(destinationZipPth, zipTarget, workDir)
+
+}
+
+// ZipDirs ...
+func ZipDirs(sourceDirPths []string, destinationZipPth string) error {
+	for _, path := range sourceDirPths {
+		if exist, err := pathutil.IsDirExists(path); err != nil {
+			return err
+		} else if !exist {
+			return fmt.Errorf("directory (%s) not exist", path)
+		}
+	}
+
+	tempDir, err := pathutil.NormalizedOSTempDirPath("zip")
+	if err != nil {
+		return err
+	}
+
+	defer func() {
+		if err = os.RemoveAll(tempDir); err != nil {
+			log.Fatal(err)
+		}
+	}()
+
+	for _, path := range sourceDirPths {
+		err := command.CopyDir(path, tempDir, false)
+		if err != nil {
+			return err
+		}
+	}
+
+	return internalZipDir(destinationZipPth, ".", tempDir)
+}
+
+func internalZipDir(destinationZipPth, zipTarget, workDir string) error {
+	opts := &command.Opts{Dir: workDir}
+	factory := command.NewFactory(env.NewRepository())
 
 	// -r - Travel the directory structure recursively
 	// -T - Test the integrity of the new zip file
 	// -y - Store symbolic links as such in the zip archive, instead of compressing and storing the file referred to by the link
-	opts := &command.Opts{Dir: workDir}
-	factory := command.NewFactory(env.NewRepository())
 	cmd := factory.Create("/usr/bin/zip", []string{"-rTy", destinationZipPth, zipTarget}, opts)
+
 	if out, err := cmd.RunAndReturnTrimmedCombinedOutput(); err != nil {
 		return fmt.Errorf("command: (%s) failed, output: %s, error: %s", cmd.PrintableCommandArgs(), out, err)
 	}

--- a/ziputil/ziputil_test.go
+++ b/ziputil/ziputil_test.go
@@ -137,6 +137,55 @@ func TestZipDirectory(t *testing.T) {
 	}
 }
 
+func TestZipDirectories(t *testing.T) {
+	t.Log("create zip from directories living at different places")
+	{
+		tmpDir, err := pathutil.NormalizedOSTempDirPath("test")
+		require.NoError(t, err)
+
+		mainDir := filepath.Join(tmpDir, "main")
+		require.NoError(t, os.MkdirAll(mainDir, 0777))
+
+		dirA := filepath.Join(mainDir, "A")
+		require.NoError(t, os.MkdirAll(dirA, 0777))
+
+		subDir := filepath.Join(tmpDir, "sub")
+		require.NoError(t, os.MkdirAll(mainDir, 0777))
+
+		dirB := filepath.Join(subDir, "B")
+		require.NoError(t, os.MkdirAll(dirB, 0777))
+
+		destinationZip := filepath.Join(tmpDir, "destinationDir.zip")
+		require.NoError(t, ZipDirs([]string{dirA, dirB}, destinationZip))
+
+		exist, err := pathutil.IsPathExists(destinationZip)
+		require.NoError(t, err)
+		require.Equal(t, true, exist, destinationZip)
+	}
+
+	t.Log("create zip from directories in the same parent directory")
+	{
+		tmpDir, err := pathutil.NormalizedOSTempDirPath("test")
+		require.NoError(t, err)
+
+		mainDir := filepath.Join(tmpDir, "main")
+		require.NoError(t, os.MkdirAll(mainDir, 0777))
+
+		dirA := filepath.Join(mainDir, "A")
+		require.NoError(t, os.MkdirAll(dirA, 0777))
+
+		dirB := filepath.Join(mainDir, "B")
+		require.NoError(t, os.MkdirAll(dirB, 0777))
+
+		destinationZip := filepath.Join(tmpDir, "destinationDir.zip")
+		require.NoError(t, ZipDirs([]string{dirA, dirB}, destinationZip))
+
+		exist, err := pathutil.IsPathExists(destinationZip)
+		require.NoError(t, err)
+		require.Equal(t, true, exist, destinationZip)
+	}
+}
+
 func TestUnZipFile(t *testing.T) {
 	t.Log("unzip zipped file")
 	{
@@ -219,6 +268,39 @@ func TestUnZipDirectory(t *testing.T) {
 		isDir, err := pathutil.IsDirExists(filepath.Join(tmpDir, "sourceDir"))
 		require.NoError(t, err)
 		require.Equal(t, true, isDir)
+	}
+
+	t.Log("unzip zipped directories")
+	{
+		// Create the multi folder zip files
+		tmpDir, err := pathutil.NormalizedOSTempDirPath("zip")
+		require.NoError(t, err)
+
+		mainDir := filepath.Join(tmpDir, "main")
+		require.NoError(t, os.MkdirAll(mainDir, 0777))
+
+		dirA := filepath.Join(mainDir, "A")
+		require.NoError(t, os.MkdirAll(dirA, 0777))
+
+		dirB := filepath.Join(mainDir, "B")
+		require.NoError(t, os.MkdirAll(dirB, 0777))
+
+		destinationZip := filepath.Join(tmpDir, "destinationDir.zip")
+		require.NoError(t, ZipDirs([]string{dirA, dirB}, destinationZip))
+
+		// unzip
+		destTmpDir, err := pathutil.NormalizedOSTempDirPath("unzip")
+		require.NoError(t, err)
+
+		require.NoError(t, UnZip(destinationZip, destTmpDir))
+
+		exist, err := pathutil.IsPathExists(filepath.Join(destTmpDir, "A"))
+		require.NoError(t, err)
+		require.Equal(t, true, exist)
+
+		exist, err = pathutil.IsPathExists(filepath.Join(destTmpDir, "B"))
+		require.NoError(t, err)
+		require.Equal(t, true, exist)
 	}
 
 	t.Log("unzip zipped content of dir")


### PR DESCRIPTION
I went through the zip command options and did not find anything that could have helped me creating zips where the directories path folder structure is not recreated inside the zip file. 

The only solution seemed like to copy the directories in a temporary place and zip the contents of that temporary folder. 