### PR TITLE
Migrate pathmodifier to v2

### DIFF
--- a/pathutil/pathutil.go
+++ b/pathutil/pathutil.go
@@ -1,6 +1,12 @@
 package pathutil
 
 import (
+	"errors"
+	"os"
+	"os/user"
+	"path/filepath"
+	"strings"
+
 	pathutilV1 "github.com/bitrise-io/go-utils/pathutil"
 )
 
@@ -50,7 +56,44 @@ func NewPathModifier() PathModifier {
 	return pathModifier{}
 }
 
-// AbsPath ...
-func (pathModifier) AbsPath(pth string) (string, error) {
-	return pathutilV1.AbsPath(pth)
+// AbsPath expands ENV vars and the ~ character then calls Go's Abs
+func (p pathModifier) AbsPath(pth string) (string, error) {
+	if pth == "" {
+		return "", errors.New("No Path provided")
+	}
+
+	pth, err := p.expandTilde(pth)
+	if err != nil {
+		return "", err
+	}
+
+	return filepath.Abs(os.ExpandEnv(pth))
+}
+
+func (pathModifier) expandTilde(pth string) (string, error) {
+	if pth == "" {
+		return "", errors.New("No Path provided")
+	}
+
+	if strings.HasPrefix(pth, "~") {
+		pth = strings.TrimPrefix(pth, "~")
+
+		if len(pth) == 0 || strings.HasPrefix(pth, "/") {
+			return os.ExpandEnv("$HOME" + pth), nil
+		}
+
+		splitPth := strings.Split(pth, "/")
+		username := splitPth[0]
+
+		usr, err := user.Lookup(username)
+		if err != nil {
+			return "", err
+		}
+
+		pathInUsrHome := strings.Join(splitPth[1:], "/")
+
+		return filepath.Join(usr.HomeDir, pathInUsrHome), nil
+	}
+
+	return pth, nil
 }

--- a/pathutil/pathutil.go
+++ b/pathutil/pathutil.go
@@ -37,3 +37,20 @@ func NewPathChecker() PathChecker {
 func (c pathChecker) IsPathExists(pth string) (bool, error) {
 	return pathutilV1.IsPathExists(pth)
 }
+
+// PathModifier ...
+type PathModifier interface {
+	AbsPath(pth string) (string, error)
+}
+
+type pathModifier struct{}
+
+// NewPathModifier ...
+func NewPathModifier() PathModifier {
+	return pathModifier{}
+}
+
+// AbsPath ...
+func (pathModifier) AbsPath(pth string) (string, error) {
+	return pathutilV1.AbsPath(pth)
+}

--- a/pathutil/pathutil_test.go
+++ b/pathutil/pathutil_test.go
@@ -1,0 +1,112 @@
+package pathutil
+
+import (
+	"os"
+	"os/user"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_pathModifier_AbsPath(t *testing.T) {
+	currDirPath, err := filepath.Abs(".")
+	require.NoError(t, err)
+	require.NotEqual(t, "", currDirPath)
+	require.NotEqual(t, ".", currDirPath)
+
+	currentUser, err := user.Current()
+	require.NoError(t, err)
+
+	sep := string(os.PathSeparator)
+	homePathEnv := filepath.Join(sep, "path", "home", "test-user")
+	require.Equal(t, nil, os.Setenv("HOME", homePathEnv))
+
+	testFileRelPathFromHome := filepath.Join("some", "file.ext")
+
+	tests := []struct {
+		name    string
+		pth     string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:    "Empty path",
+			pth:     "",
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name: "Current dir",
+			pth:  ".",
+			want: currDirPath,
+		},
+		{
+			name: "Relative dir",
+			pth:  filepath.Join(homePathEnv, "..", "test-user"),
+			want: homePathEnv,
+		},
+		{
+			name: "Environment variable",
+			pth:  filepath.Join("$HOME", testFileRelPathFromHome),
+			want: filepath.Join(homePathEnv, testFileRelPathFromHome),
+		},
+		{
+			name: "Tilde with path",
+			pth:  filepath.Join("~", testFileRelPathFromHome),
+			want: filepath.Join(homePathEnv, testFileRelPathFromHome),
+		},
+		{
+			name: "Tilde with relative path",
+			pth:  "~" + sep + ".." + sep + "test-user",
+			want: homePathEnv,
+		},
+		{
+			name: "Tilde with slash suffix",
+			pth:  "~" + sep,
+			want: homePathEnv,
+		},
+		{
+			name: "Tilde only",
+			pth:  "~",
+			want: homePathEnv,
+		},
+		{
+			name: "Tilde + username",
+			pth:  "~" + currentUser.Name,
+			want: currentUser.HomeDir,
+		},
+		{
+			name:    "Tilde with nonexistent username",
+			pth:     filepath.Join("~testaccnotexist", "folder"),
+			wantErr: true,
+		},
+		{
+			name: "Tilde + username, slash suffix",
+			pth:  "~" + currentUser.Name + sep,
+			want: currentUser.HomeDir,
+		},
+		{
+			name: "Tilde + username with path",
+			pth:  filepath.Join("~"+currentUser.Name, "folder"),
+			want: filepath.Join(currentUser.HomeDir, "folder"),
+		},
+		{
+			name: "Tilde as directory name",
+			pth:  filepath.Join(sep, "test", "~", "in", "name"),
+			want: filepath.Join(sep, "test", "~", "in", "name"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := pathModifier{}
+			got, err := p.AbsPath(tt.pth)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("pathModifier.AbsPath() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			require.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our Step library!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [X] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [X] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *MAJOR/MINOR/PATCH* [version update](https://semver.org/)

### Context

Migrated pathmodifier to the v2 version of the library.

Resolves: https://bitrise.atlassian.net/browse/STEP-1719

### Changes

* Migrate pathmodifier to v2

* Migrate AbsPath implementation to v2

* Moved implementation from v1 for CreateTempDir and IsPathExists

### Decisions

Remove v1 references, instead copy implementation and tests.