### PR TITLE
Change timestamp of analytics events to microseconds

### DIFF
--- a/analytics/event.go
+++ b/analytics/event.go
@@ -20,7 +20,7 @@ func newEvent(name string, properties []Properties) event {
 	return event{
 		ID:         uuid.Must(uuid.NewV4()).String(),
 		EventName:  name,
-		Timestamp:  time.Now().UnixNano() / int64(time.Millisecond),
+		Timestamp:  time.Now().UnixNano() / int64(time.Microsecond),
 		Properties: merge(properties),
 	}
 }


### PR DESCRIPTION
Microseconds are the default granularity of BigQuery timestamps so it
makes logical that we also use microseconds for better resolution