### PR TITLE
Introduce timeout for waiting analytics event sending to finish

### DIFF
--- a/analytics/client.go
+++ b/analytics/client.go
@@ -10,7 +10,7 @@ import (
 )
 
 const trackEndpoint = "https://bitrise-step-analytics.herokuapp.com/track"
-const timeOut = time.Second * 30
+const timeOut = 30 * time.Second
 
 // Client ...
 type Client interface {


### PR DESCRIPTION
We wouldn't want to block CLI or any other processes indefinitely
waiting for analytics events to be sent up to the server (in case of
network issues or other causes). We introduce a global limit, after this
we're going to proceed with the execution. This way sending the events
will be "best-effort" and may result in missing events in rare circumstances.