### PR TITLE
Improve exit code error checking utilizing go error unwrap functionality

### DIFF
--- a/errorutil/errorutil.go
+++ b/errorutil/errorutil.go
@@ -2,12 +2,14 @@
 package errorutil
 
 import (
+	"errors"
 	"os/exec"
 	"regexp"
 )
 
 func exitCode(err error) int {
-	if exitError, ok := err.(*exec.ExitError); ok {
+	var exitError *exec.ExitError
+	if errors.As(err, &exitError) {
 		return exitError.ProcessState.ExitCode()
 	}
 	return -1
@@ -22,7 +24,7 @@ func IsExitStatusError(err error) bool {
 func IsExitStatusErrorStr(errString string) bool {
 	// https://golang.org/src/os/exec_posix.go?s=2421:2459#L87
 	// example exit status error string: exit status 1
-	var rex = regexp.MustCompile(`^exit status [0-9]{1,3}$`)
+	var rex = regexp.MustCompile(`^exit status \d{1,3}$`)
 	return rex.MatchString(errString)
 }
 


### PR DESCRIPTION
We'd like to utilise go's error wrapping functionality but still wish to be able to keep original ExitError's context to extract exit codes