### PR TITLE
Add runtime checks for CPU architecture

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,4 +7,5 @@ require (
 	github.com/gofrs/uuid v4.2.0+incompatible
 	github.com/mitchellh/mapstructure v1.4.3
 	github.com/stretchr/testify v1.7.0
+	golang.org/x/sys v0.0.0-20220712014510-0a85c31ab51e
 )

--- a/go.sum
+++ b/go.sum
@@ -29,6 +29,8 @@ golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211205182925-97ca703d548d/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220712014510-0a85c31ab51e h1:NHvCuwuS43lGnYhten69ZWqi2QOj/CiDNcKbVqwVoew=
+golang.org/x/sys v0.0.0-20220712014510-0a85c31ab51e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=

--- a/system/cpu.go
+++ b/system/cpu.go
@@ -8,6 +8,7 @@ import (
 
 type cpu struct{}
 
+// CPU is a singleton that returns information about the CPU
 var CPU cpu
 
 // Architecture returns the CPU's architecture name as a string
@@ -31,7 +32,7 @@ func (cpu) IsARM() (bool, error) {
 
 	if err != nil {
 		return false, err
-	} else {
-		return strings.Contains(cpuType, "arm"), nil
 	}
+
+	return strings.Contains(cpuType, "arm"), nil
 }

--- a/system/cpu.go
+++ b/system/cpu.go
@@ -12,6 +12,10 @@ type cpu struct{}
 var CPU cpu
 
 // Architecture returns the CPU's architecture name as a string
+//
+// Some example return values:
+//   - "x86_64"
+//   - "arm64"
 func (cpu) Architecture() (string, error) {
 	var utsname unix.Utsname
 	err := unix.Uname(&utsname)

--- a/system/cpu.go
+++ b/system/cpu.go
@@ -1,0 +1,37 @@
+package system
+
+import (
+	"strings"
+
+	"golang.org/x/sys/unix"
+)
+
+type cpu struct{}
+
+var CPU cpu
+
+// Architecture returns the CPU's architecture name as a string
+func (cpu) Architecture() (string, error) {
+	var utsname unix.Utsname
+	err := unix.Uname(&utsname)
+	if err != nil {
+		return "", err
+	}
+
+	architecture := string(utsname.Machine[:])
+	architecture = strings.Trim(architecture, "\x00")
+	return architecture, nil
+}
+
+// IsARM returns true if the CPU's architecture is ARM
+//
+// Specifically, it returns true if the architecture's name contains the string 'arm'
+func (cpu) IsARM() (bool, error) {
+	cpuType, err := CPU.Architecture()
+
+	if err != nil {
+		return false, err
+	} else {
+		return strings.Contains(cpuType, "arm"), nil
+	}
+}

--- a/system/cpu.go
+++ b/system/cpu.go
@@ -14,8 +14,8 @@ var CPU cpu
 // Architecture returns the CPU's architecture name as a string
 //
 // Some example return values:
-//   - "x86_64"
-//   - "arm64"
+//   - x86_64
+//   - arm64
 func (cpu) Architecture() (string, error) {
 	var utsname unix.Utsname
 	err := unix.Uname(&utsname)

--- a/system/cpu_test.go
+++ b/system/cpu_test.go
@@ -1,0 +1,52 @@
+package system
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// These tests aren't perfectly isolated, because they depend on the environment
+// they're being run in, but they are better than having nothing.
+
+func TestCpu_Architecture(t *testing.T) {
+	// Given
+	unameCmd := exec.Command("uname", "-m")
+	unameOut, err := unameCmd.Output()
+	if err != nil {
+		t.Errorf("uname failed: %v", err)
+	}
+	unameOutString := string(unameOut)
+	unameOutString = strings.TrimSpace(unameOutString)
+
+	// When
+	architecture, err := CPU.Architecture()
+	if err != nil {
+		t.Errorf("CPU.Architecture() failed: %v", err)
+	}
+
+	// Then
+	require.Equal(t, unameOutString, architecture)
+}
+
+func TestCpu_IsARM(t *testing.T) {
+	// Given
+	unameCmd := exec.Command("uname", "-m")
+	unameOut, err := unameCmd.Output()
+	if err != nil {
+		t.Errorf("uname failed: %v", err)
+	}
+	unameOutString := string(unameOut)
+	unameOutString = strings.TrimSpace(unameOutString)
+
+	// When
+	isARM, err := CPU.IsARM()
+	if err != nil {
+		t.Errorf("CPU.IsARM() failed: %v", err)
+	}
+
+	// Then
+	require.Equal(t, strings.Contains(unameOutString, "arm"), isARM)
+}


### PR DESCRIPTION
## Context

I'm working on updating the avd-manager and wait-for-android-emulator steps to have some conditional behavior based on the CPU-type they are being run on, so I needed a way to check the CPU-type at runtime. This seemed like something that could be useful outside of these two Steps, so I figured I'd add it to go-utils for other consumers to use as well.

Here is an example of how this change could be used within a Step:

```go
cpuIsARM, err := system.CPU.IsARM()
if err != nil {
	log.Errorf("Failed to check CPU: %s", err)
} else if cpuIsARM {
	log.Warnf("This Step is not yet supported on Apple Silicon (M1) machines. If you're unable to find a solution to this error, try running this Workflow on an Intel-based machine type.")
}
```

From here: https://github.com/bitrise-steplib/steps-avd-manager/blob/c175c0975ac38fdaef32051e39e8e1d240f7df64/main.go#L86-L91

## Changes

- Creates a `system` module with a `cpu` type.
- Adds methods to check the CPU architecture, and a convenience method to return a boolean of if the CPU is arm or not.
- Adds a couple tests of the new module.