### PR TITLE
Don't hardcode logger instance in analytics

### DIFF
--- a/analytics/track.go
+++ b/analytics/track.go
@@ -27,8 +27,8 @@ type tracker struct {
 }
 
 // NewDefaultTracker ...
-func NewDefaultTracker(properties ...Properties) Tracker {
-	return NewTracker(NewDefaultClient(log.NewLogger()), timeout, properties...)
+func NewDefaultTracker(logger log.Logger, properties ...Properties) Tracker {
+	return NewTracker(NewDefaultClient(logger), timeout, properties...)
 }
 
 // NewTracker ...


### PR DESCRIPTION
At the moment the logger instance is hardcoded into `analytics.Client`. This makes it impossible to set the log level to debug, even though there are messages logged with the debug level.