### PR TITLE
Add retryable HTTP client from v1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.16
 require (
 	github.com/bitrise-io/go-utils v1.0.1
 	github.com/gofrs/uuid v4.2.0+incompatible
+	github.com/hashicorp/go-retryablehttp v0.7.1
 	github.com/mitchellh/mapstructure v1.4.3
 	github.com/stretchr/testify v1.7.0
 	golang.org/x/sys v0.0.0-20220712014510-0a85c31ab51e

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,9 @@ github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9n
 github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/SoxCXGY6BqNFT48=
 github.com/hashicorp/go-hclog v0.9.2 h1:CG6TE5H9/JXsFWJCfoIVpKFIkFe6ysEuHirp4DxCsHI=
 github.com/hashicorp/go-hclog v0.9.2/go.mod h1:5CU+agLiy3J7N7QjHK5d05KxGsuXiQLrjA0H7acj2lQ=
-github.com/hashicorp/go-retryablehttp v0.7.0 h1:eu1EI/mbirUgP5C8hVsTNaGZreBDlYiwC1FZWkvQPQ4=
 github.com/hashicorp/go-retryablehttp v0.7.0/go.mod h1:vAew36LZh98gCBJNLH42IQ1ER/9wtLZZ8meHqQvEYWY=
+github.com/hashicorp/go-retryablehttp v0.7.1 h1:sUiuQAnLlbvmExtFQs72iFW/HXeUn8Z1aJLQ4LJJbTQ=
+github.com/hashicorp/go-retryablehttp v0.7.1/go.mod h1:vAew36LZh98gCBJNLH42IQ1ER/9wtLZZ8meHqQvEYWY=
 github.com/mitchellh/mapstructure v1.4.3 h1:OVowDSCllw/YjdLkam3/sm7wEtOy59d8ndGgCcyj8cs=
 github.com/mitchellh/mapstructure v1.4.3/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/http/retryhttp.go
+++ b/http/retryhttp.go
@@ -5,21 +5,21 @@ import (
 	"github.com/hashicorp/go-retryablehttp"
 )
 
-// HTTPLogAdaptor adapts the retryablehttp.Logger interface to the go-utils logger.
-type HTTPLogAdaptor struct {
+// NewHTTPClient returns a retryable HTTP client with common defaults
+func NewHTTPClient(logger log.Logger) *retryablehttp.Client {
+	client := retryablehttp.NewClient()
+	client.Logger = &httpLogAdaptor{logger: logger}
+	client.ErrorHandler = retryablehttp.PassthroughErrorHandler
+
+	return client
+}
+
+// httpLogAdaptor adapts the retryablehttp.Logger interface to the go-utils logger.
+type httpLogAdaptor struct {
 	logger log.Logger
 }
 
 // Printf implements the retryablehttp.Logger interface
-func (a *HTTPLogAdaptor) Printf(fmtStr string, vars ...interface{}) {
+func (a *httpLogAdaptor) Printf(fmtStr string, vars ...interface{}) {
 	a.logger.Debugf(fmtStr, vars...)
-}
-
-// NewHTTPClient returns a retryable HTTP client with common defaults
-func NewHTTPClient(logger log.Logger) *retryablehttp.Client {
-	client := retryablehttp.NewClient()
-	client.Logger = &HTTPLogAdaptor{}
-	client.ErrorHandler = retryablehttp.PassthroughErrorHandler
-
-	return client
 }

--- a/http/retryhttp.go
+++ b/http/retryhttp.go
@@ -1,0 +1,25 @@
+package http
+
+import (
+	"github.com/bitrise-io/go-utils/v2/log"
+	"github.com/hashicorp/go-retryablehttp"
+)
+
+// HTTPLogAdaptor adapts the retryablehttp.Logger interface to the go-utils logger.
+type HTTPLogAdaptor struct {
+	logger log.Logger
+}
+
+// Printf implements the retryablehttp.Logger interface
+func (a *HTTPLogAdaptor) Printf(fmtStr string, vars ...interface{}) {
+	a.logger.Debugf(fmtStr, vars...)
+}
+
+// NewHTTPClient returns a retryable HTTP client with common defaults
+func NewHTTPClient(logger log.Logger) *retryablehttp.Client {
+	client := retryablehttp.NewClient()
+	client.Logger = &HTTPLogAdaptor{}
+	client.ErrorHandler = retryablehttp.PassthroughErrorHandler
+
+	return client
+}

--- a/retryhttp/retryhttp.go
+++ b/retryhttp/retryhttp.go
@@ -5,8 +5,8 @@ import (
 	"github.com/hashicorp/go-retryablehttp"
 )
 
-// NewHTTPClient returns a retryable HTTP client with common defaults
-func NewHTTPClient(logger log.Logger) *retryablehttp.Client {
+// NewClient returns a retryable HTTP client with common defaults
+func NewClient(logger log.Logger) *retryablehttp.Client {
 	client := retryablehttp.NewClient()
 	client.Logger = &httpLogAdaptor{logger: logger}
 	client.ErrorHandler = retryablehttp.PassthroughErrorHandler

--- a/retryhttp/retryhttp.go
+++ b/retryhttp/retryhttp.go
@@ -1,4 +1,4 @@
-package http
+package retryhttp
 
 import (
 	"github.com/bitrise-io/go-utils/v2/log"


### PR DESCRIPTION
Moves our preconfigured retryable HTTP client [in v1](https://github.com/bitrise-io/go-utils/blob/v1/retry/retryhttp.go) to the current master.