### PR TITLE
Remove go-utils/v1 dependency

### DIFF
--- a/analytics/client.go
+++ b/analytics/client.go
@@ -6,8 +6,8 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/bitrise-io/go-utils/retry"
 	"github.com/bitrise-io/go-utils/v2/log"
+	"github.com/bitrise-io/go-utils/v2/retryhttp"
 )
 
 const trackEndpoint = "https://bitrise-step-analytics.herokuapp.com/track"
@@ -26,7 +26,7 @@ type client struct {
 
 // NewDefaultClient ...
 func NewDefaultClient(logger log.Logger, timeout time.Duration) Client {
-	httpClient := retry.NewHTTPClient().StandardClient()
+	httpClient := retryhttp.NewClient(logger).StandardClient()
 	httpClient.Timeout = timeout
 	return NewClient(httpClient, trackEndpoint, logger, timeout)
 }

--- a/go.mod
+++ b/go.mod
@@ -1,12 +1,19 @@
 module github.com/bitrise-io/go-utils/v2
 
-go 1.16
+go 1.17
 
 require (
-	github.com/bitrise-io/go-utils v1.0.1
 	github.com/gofrs/uuid v4.2.0+incompatible
 	github.com/hashicorp/go-retryablehttp v0.7.1
 	github.com/mitchellh/mapstructure v1.4.3
 	github.com/stretchr/testify v1.7.0
 	golang.org/x/sys v0.0.0-20220712014510-0a85c31ab51e
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/stretchr/objx v0.3.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-github.com/bitrise-io/go-utils v1.0.1 h1:e7mepVBkVN1DXRPESNXb0djEw6bxB6B93p/Q74zzcvk=
-github.com/bitrise-io/go-utils v1.0.1/go.mod h1:ZY1DI+fEpZuFpO9szgDeICM4QbqoWVt0RSY3tRI1heY=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -10,7 +8,6 @@ github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9n
 github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/SoxCXGY6BqNFT48=
 github.com/hashicorp/go-hclog v0.9.2 h1:CG6TE5H9/JXsFWJCfoIVpKFIkFe6ysEuHirp4DxCsHI=
 github.com/hashicorp/go-hclog v0.9.2/go.mod h1:5CU+agLiy3J7N7QjHK5d05KxGsuXiQLrjA0H7acj2lQ=
-github.com/hashicorp/go-retryablehttp v0.7.0/go.mod h1:vAew36LZh98gCBJNLH42IQ1ER/9wtLZZ8meHqQvEYWY=
 github.com/hashicorp/go-retryablehttp v0.7.1 h1:sUiuQAnLlbvmExtFQs72iFW/HXeUn8Z1aJLQ4LJJbTQ=
 github.com/hashicorp/go-retryablehttp v0.7.1/go.mod h1:vAew36LZh98gCBJNLH42IQ1ER/9wtLZZ8meHqQvEYWY=
 github.com/mitchellh/mapstructure v1.4.3 h1:OVowDSCllw/YjdLkam3/sm7wEtOy59d8ndGgCcyj8cs=
@@ -24,21 +21,10 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-golang.org/x/crypto v0.0.0-20211202192323-5770296d904e/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
-golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
-golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20211205182925-97ca703d548d/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220712014510-0a85c31ab51e h1:NHvCuwuS43lGnYhten69ZWqi2QOj/CiDNcKbVqwVoew=
 golang.org/x/sys v0.0.0-20220712014510-0a85c31ab51e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
-golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
-golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
-golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b h1:h8qDotaEPuJATrMmW04NCwg7v22aHH28wwpauUhK9Oo=
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/log/colorstring/colorstring.go
+++ b/log/colorstring/colorstring.go
@@ -1,0 +1,111 @@
+package colorstring
+
+// ANSI color escape sequences
+
+import (
+	"fmt"
+)
+
+// Color ...
+type Color string
+
+const (
+	blackColor   Color = "\x1b[30;1m"
+	redColor     Color = "\x1b[31;1m"
+	greenColor   Color = "\x1b[32;1m"
+	yellowColor  Color = "\x1b[33;1m"
+	blueColor    Color = "\x1b[34;1m"
+	magentaColor Color = "\x1b[35;1m"
+	cyanColor    Color = "\x1b[36;1m"
+	resetColor   Color = "\x1b[0m"
+)
+
+// ColorFunc ...
+type ColorFunc func(a ...interface{}) string
+
+func addColor(color Color, msg string) string {
+	return string(color) + msg + string(resetColor)
+}
+
+// NoColor ...
+func NoColor(a ...interface{}) string {
+	return fmt.Sprint(a...)
+}
+
+// Black ...
+func Black(a ...interface{}) string {
+	return addColor(blackColor, fmt.Sprint(a...))
+}
+
+// Red ...
+func Red(a ...interface{}) string {
+	return addColor(redColor, fmt.Sprint(a...))
+}
+
+// Green ...
+func Green(a ...interface{}) string {
+	return addColor(greenColor, fmt.Sprint(a...))
+}
+
+// Yellow ...
+func Yellow(a ...interface{}) string {
+	return addColor(yellowColor, fmt.Sprint(a...))
+}
+
+// Blue ...
+func Blue(a ...interface{}) string {
+	return addColor(blueColor, fmt.Sprint(a...))
+}
+
+// Magenta ...
+func Magenta(a ...interface{}) string {
+	return addColor(magentaColor, fmt.Sprint(a...))
+}
+
+// Cyan ...
+func Cyan(a ...interface{}) string {
+	return addColor(cyanColor, fmt.Sprint(a...))
+}
+
+// ColorfFunc ...
+type ColorfFunc func(format string, a ...interface{}) string
+
+// NoColorf ...
+func NoColorf(format string, a ...interface{}) string {
+	return NoColor(fmt.Sprintf(format, a...))
+}
+
+// Blackf ...
+func Blackf(format string, a ...interface{}) string {
+	return Black(fmt.Sprintf(format, a...))
+}
+
+// Redf ...
+func Redf(format string, a ...interface{}) string {
+	return Red(fmt.Sprintf(format, a...))
+}
+
+// Greenf ...
+func Greenf(format string, a ...interface{}) string {
+	return Green(fmt.Sprintf(format, a...))
+}
+
+// Yellowf ...
+func Yellowf(format string, a ...interface{}) string {
+	return Yellow(fmt.Sprintf(format, a...))
+}
+
+// Bluef ...
+func Bluef(format string, a ...interface{}) string {
+	return Blue(fmt.Sprintf(format, a...))
+}
+
+// Magentaf ...
+func Magentaf(format string, a ...interface{}) string {
+	return Magenta(fmt.Sprintf(format, a...))
+}
+
+// Cyanf ...
+func Cyanf(format string, a ...interface{}) string {
+	return Cyan(fmt.Sprintf(format, a...))
+}

--- a/log/colorstring/colorstring_test.go
+++ b/log/colorstring/colorstring_test.go
@@ -1,0 +1,54 @@
+package colorstring
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAddColor(t *testing.T) {
+	/*
+	  blackColor   Color = "\x1b[30;1m"
+	  resetColor   Color = "\x1b[0m"
+	*/
+
+	t.Log("colored_string = color + string + reset_color")
+	{
+		desiredColored := "\x1b[30;1m" + "test" + "\x1b[0m"
+		colored := addColor(blackColor, "test")
+		require.Equal(t, desiredColored, colored)
+	}
+}
+
+func TestBlack(t *testing.T) {
+	t.Log("Simple string can be blacked")
+	{
+		desiredColored := "\x1b[30;1m" + "test" + "\x1b[0m"
+		colored := Black("test")
+		require.Equal(t, desiredColored, colored)
+	}
+
+	t.Log("Multiple strings can be blacked")
+	{
+		desiredColored := "\x1b[30;1m" + "Hello Bitrise !" + "\x1b[0m"
+		colored := Black("Hello ", "Bitrise ", "!")
+		require.Equal(t, desiredColored, colored)
+	}
+}
+
+func TestBlackf(t *testing.T) {
+	t.Log("Simple format can be blacked")
+	{
+		desiredColored := "\x1b[30;1m" + fmt.Sprintf("Hello %s", "bitrise") + "\x1b[0m"
+		colored := Blackf("Hello %s", "bitrise")
+		require.Equal(t, desiredColored, colored)
+	}
+
+	t.Log("Complex format can be blacked")
+	{
+		desiredColored := "\x1b[30;1m" + fmt.Sprintf("Hello %s %s", "bitrise", "!") + "\x1b[0m"
+		colored := Blackf("Hello %s %s", "bitrise", "!")
+		require.Equal(t, desiredColored, colored)
+	}
+}

--- a/log/severity.go
+++ b/log/severity.go
@@ -1,6 +1,6 @@
 package log
 
-import "github.com/bitrise-io/go-utils/colorstring"
+import "github.com/bitrise-io/go-utils/v2/log/colorstring"
 
 // Severity ...
 type Severity uint8


### PR DESCRIPTION
This removes the last remaining circular dependencies from this library.

Changes:
- Make `analytics/client` use the retry HTTP client from `retryhttp`
- Move the `colorstring` package over from v1 as `log/colorstring`. Everying that was public in v1 is still public in v2.