### PR TITLE
Expose message coloring as a public function

### DIFF
--- a/log/coloring.go
+++ b/log/coloring.go
@@ -1,0 +1,6 @@
+package log
+
+// FormatWithSeverityColor ...
+func FormatWithSeverityColor(s Severity, format string, v ...interface{}) string {
+	return severityColorFuncMap[s](format, v...)
+}

--- a/log/coloring_test.go
+++ b/log/coloring_test.go
@@ -1,0 +1,64 @@
+package log
+
+import (
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func Test_format_with_severity_color(t *testing.T) {
+	testcases := []struct {
+		title string
+
+		expectedOutput string
+		format         string
+		params         string
+		severity       Severity
+	}{
+		{
+			title: "Error",
+
+			expectedOutput: "\x1b[31;1mtest log\x1b[0m",
+			format:         "test %s",
+			params:         "log",
+			severity:       errorSeverity,
+		},
+		{
+			title: "Warn",
+
+			expectedOutput: "\x1b[33;1mtest log\x1b[0m",
+			format:         "test %s",
+			params:         "log",
+			severity:       warnSeverity,
+		},
+		{
+			title: "Debug",
+
+			expectedOutput: "\x1b[35;1mtest log\x1b[0m",
+			format:         "test %s",
+			params:         "log",
+			severity:       debugSeverity,
+		},
+		{
+			title: "Info",
+
+			expectedOutput: "\x1b[34;1mtest log\x1b[0m",
+			format:         "test %s",
+			params:         "log",
+			severity:       infoSeverity,
+		},
+		{
+			title: "Done",
+
+			expectedOutput: "\x1b[32;1mtest log\x1b[0m",
+			format:         "test %s",
+			params:         "log",
+			severity:       doneSeverity,
+		},
+	}
+
+	for _, testCase := range testcases {
+		t.Run(testCase.title, func(t *testing.T) {
+			require.Equal(t, testCase.expectedOutput, FormatWithSeverityColor(testCase.severity, testCase.format, testCase.params))
+		})
+	}
+}

--- a/log/log.go
+++ b/log/log.go
@@ -122,8 +122,7 @@ func (l *logger) prefixCurrentTime(message string) string {
 }
 
 func (l *logger) createLogMsg(severity Severity, withTime bool, format string, v ...interface{}) string {
-	colorFunc := severityColorFuncMap[severity]
-	message := colorFunc(format, v...)
+	message := FormatWithSeverityColor(severity, format, v...)
 	if withTime {
 		message = l.prefixCurrentTime(message)
 	}


### PR DESCRIPTION
In the existing logging system the log level <-> color code association is hidden from the public. This PR will introduce a public function to expose this log coloring. This will be used in the log service when processing the structured logs.