### PR TITLE
Use standard linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,26 @@
+run:
+  skip-dirs:
+  - .*/mocks
+
+issues:
+  # https://github.com/golangci/golangci-lint/issues/2439
+  exclude-use-default: false
+
+linters:
+  enable:
+  - errcheck
+  - gosimple
+  - govet
+  - ineffassign
+  - staticcheck
+  - typecheck
+  - unused
+  - revive
+
+linters-settings:
+  revive:
+    severity: error
+    rules:
+    - name: exported
+      arguments:
+      - checkPrivateReceivers

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1,11 +1,13 @@
 format_version: "11"
 default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
 
-
 workflows:
   test:
     steps:
-    - go-list:
-    - golint:
-    - errcheck:
-    - go-test:
+    - git::https://github.com/bitrise-steplib/steps-check.git:
+        title: Lint
+        inputs:
+        - workflow: lint
+        - skip_step_yml_validation: "yes"
+    - go-list: { }
+    - go-test: { }


### PR DESCRIPTION
Use the standard linters and config we use in other step repos.

This PR drops errcheck and golint in favor of golangci-lint through the check internal step.

