### PR TITLE
Add `IsDirExists()` utility

### DIFF
--- a/pathutil/pathutil.go
+++ b/pathutil/pathutil.go
@@ -34,6 +34,7 @@ func (pathProvider) CreateTempDir(prefix string) (dir string, err error) {
 // PathChecker ...
 type PathChecker interface {
 	IsPathExists(pth string) (bool, error)
+	IsDirExists(pth string) (bool, error)
 }
 
 type pathChecker struct{}
@@ -49,9 +50,15 @@ func (c pathChecker) IsPathExists(pth string) (bool, error) {
 	return isExists, err
 }
 
+// IsDirExists ...
+func (c pathChecker) IsDirExists(pth string) (bool, error) {
+	info, isExists, err := c.genericIsPathExists(pth)
+	return isExists && info.IsDir(), err
+}
+
 func (pathChecker) genericIsPathExists(pth string) (os.FileInfo, bool, error) {
 	if pth == "" {
-		return nil, false, errors.New("No path provided")
+		return nil, false, errors.New("no path provided")
 	}
 
 	fileInf, err := os.Lstat(pth)

--- a/pathutil/pathutil_test.go
+++ b/pathutil/pathutil_test.go
@@ -1,6 +1,7 @@
 package pathutil
 
 import (
+	"io/ioutil"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -70,6 +71,59 @@ func Test_pathChecker_IsPathExists(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			c := pathChecker{}
 			got, err := c.IsPathExists(tt.pth)
+
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func Test_pathChecker_IsDirExists(t *testing.T) {
+	tmpDirPath := t.TempDir()
+	tmpFilePath := filepath.Join(t.TempDir(), "hello.txt")
+	require.NoError(t, ioutil.WriteFile(tmpFilePath, []byte("hello"), 0700))
+
+	tests := []struct {
+		name    string
+		path    string
+		want    bool
+		wantErr bool
+	}{
+		{
+			name: "path does not exists",
+			path: filepath.Join("this", "should", "not", "exist"),
+			want: false,
+		},
+		{
+			name: "current dir",
+			path: ".",
+			want: true,
+		},
+		{
+			name:    "empty path",
+			path:    "",
+			want:    false,
+			wantErr: true,
+		},
+		{
+			name: "existing file",
+			path: tmpFilePath,
+			want: false,
+		},
+		{
+			name: "existing dir",
+			path: tmpDirPath,
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := pathChecker{}
+			got, err := c.IsDirExists(tt.path)
 
 			if tt.wantErr {
 				require.Error(t, err)


### PR DESCRIPTION
Re-introduce the `IsDirExists()` utility function that was present in `go-utils/v1`.

It's widely used in the step codebases: https://cs.github.com/?scope=org:bitrise-steplib&scopeName=bitrise-steplib&q=IsDirExists(