### PR TITLE
[CI-267] Added error formatting function

### DIFF
--- a/errorutil/formatted_error.go
+++ b/errorutil/formatted_error.go
@@ -1,0 +1,68 @@
+package errorutil
+
+import (
+	"errors"
+	"strings"
+)
+
+// FormattedError ...
+func FormattedError(err error) string {
+	var formatted string
+
+	i := -1
+	for {
+		i++
+
+		reason := err.Error()
+
+		if err = errors.Unwrap(err); err == nil {
+			formatted = appendError(formatted, reason, i, true)
+			return formatted
+		}
+
+		reason = strings.TrimSuffix(reason, err.Error())
+		reason = strings.TrimRight(reason, " ")
+		reason = strings.TrimSuffix(reason, ":")
+
+		formatted = appendError(formatted, reason, i, false)
+	}
+}
+
+func appendError(errorMessage, reason string, i int, last bool) string {
+	if i == 0 {
+		errorMessage = indentedReason(reason, i)
+	} else {
+		errorMessage += "\n"
+		errorMessage += indentedReason(reason, i)
+	}
+
+	if !last {
+		errorMessage += ":"
+	}
+
+	return errorMessage
+}
+
+func indentedReason(reason string, level int) string {
+	var lines []string
+	split := strings.Split(reason, "\n")
+	for _, line := range split {
+		line = strings.TrimLeft(line, " ")
+		line = strings.TrimRight(line, "\n")
+		line = strings.TrimRight(line, " ")
+		if line == "" {
+			continue
+		}
+		lines = append(lines, line)
+	}
+
+	var indented string
+	for i, line := range lines {
+		indented += strings.Repeat("  ", level)
+		indented += line
+		if i != len(lines)-1 {
+			indented += "\n"
+		}
+	}
+	return indented
+}

--- a/errorutil/formatted_error_test.go
+++ b/errorutil/formatted_error_test.go
@@ -1,0 +1,62 @@
+package errorutil
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+func TestFormattedError(t *testing.T) {
+	tests := []struct {
+		name               string
+		error              func() error
+		wantFormattedError string
+	}{
+		{
+			name: "Single error",
+			error: func() error {
+				return errors.New("this is a failed error")
+			},
+			wantFormattedError: "this is a failed error",
+		},
+		{
+			name: "Single multiline error",
+			error: func() error {
+				return errors.New("this is a failed error\nAnother line\nanother line")
+			},
+			wantFormattedError: "this is a failed error\nAnother line\nanother line",
+		},
+		{
+			name: "Multiple wrapped errors",
+			error: func() error {
+				err := errors.New("the magic has failed")
+				err = fmt.Errorf("second layer also failed: %w", err)
+				err = fmt.Errorf("third layer also failed: %w", err)
+				err = fmt.Errorf("fourth layer also failed: %w", err)
+				return err
+			}, wantFormattedError: `fourth layer also failed:
+  third layer also failed:
+    second layer also failed:
+      the magic has failed`,
+		},
+		{
+			name: "Multiple non-wrapped errors",
+			error: func() error {
+				err := errors.New("the magic has failed")
+				err = fmt.Errorf("second layer also failed: %s", err)
+				err = fmt.Errorf("third layer also failed: %s", err)
+				err = fmt.Errorf("fourth layer also failed: %s", err)
+				return err
+			}, wantFormattedError: "fourth layer also failed: third layer also failed: second layer also failed: the magic has failed",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			formatted := FormattedError(tt.error())
+
+			if formatted != tt.wantFormattedError {
+				t.Errorf("got formatted error = %s, want %s", formatted, tt.wantFormattedError)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR extracts the wrapped error formatting which already lives in the fastlane and xcode-archive steps.

It takes an error and starts to unwrap it. Every error instance it finds will be printed with an ever increasing indentation for better readability. 