### PR TITLE
Add arbitrary options to git clone commands

### DIFF
--- a/command/git/commands.go
+++ b/command/git/commands.go
@@ -10,13 +10,24 @@ func (g *Git) Init() *command.Model {
 }
 
 // Clone a repository into a new directory.
-func (g *Git) Clone(repo string) *command.Model {
-	return g.command("clone", repo, ".")
+func (g *Git) Clone(repo string, opts ...string) *command.Model {
+	args := []string{"clone"}
+	args = append(args, opts...)
+	args = append(args, repo)
+	args = append(args, ".")
+	return g.command(args...)
 }
 
 // CloneTagOrBranch is recursively clones a tag or branch.
-func (g *Git) CloneTagOrBranch(repo, tagOrBranch string) *command.Model {
-	return g.command("clone", "--recursive", "--branch", tagOrBranch, repo, ".")
+func (g *Git) CloneTagOrBranch(repo, tagOrBranch string, opts ...string) *command.Model {
+	args := []string{"clone"}
+	args = append(args, "--recursive")
+	args = append(args, []string{"--branch", tagOrBranch}...)
+	args = append(args, opts...)
+	args = append(args, repo)
+	args = append(args, ".")
+
+	return g.command(args...)
 }
 
 // RemoteList shows a list of existing remote urls with remote names.

--- a/command/git/commands_test.go
+++ b/command/git/commands_test.go
@@ -36,6 +36,23 @@ func TestGitCommands(t *testing.T) {
 			command: (&Git{}).Log("%H", "refs/head/hcnarb"),
 			want:    `git "log" "-1" "--format=%H" "refs/head/hcnarb"`,
 		},
+		// Clone
+		{
+			command: (&Git{}).Clone("https://github.com/bitrise-io/go-utils.git"),
+			want:    `git "clone" "https://github.com/bitrise-io/go-utils.git" "."`,
+		},
+		{
+			command: (&Git{}).Clone("https://github.com/bitrise-io/go-utils.git", "--depth=1"),
+			want:    `git "clone" "--depth=1" "https://github.com/bitrise-io/go-utils.git" "."`,
+		},
+		{
+			command: (&Git{}).CloneTagOrBranch("https://github.com/bitrise-io/go-utils.git", "v1"),
+			want:    `git "clone" "--recursive" "--branch" "v1" "https://github.com/bitrise-io/go-utils.git" "."`,
+		},
+		{
+			command: (&Git{}).CloneTagOrBranch("https://github.com/bitrise-io/go-utils.git", "v1", "--depth=1"),
+			want:    `git "clone" "--recursive" "--branch" "v1" "--depth=1" "https://github.com/bitrise-io/go-utils.git" "."`,
+		},
 	}
 
 	for _, testCase := range testCases {


### PR DESCRIPTION
### Context

https://github.com/bitrise-io/bitrise/pull/838

### Changes

Add a variadic `opts string...` argument to the `Clone()` functions, matching the other git command functions. This allows passing additional flags to the `git clone` command, such as the `--depth=1` flag that does a shallow clone.

In the case of `CloneTagOrBranch()`, I decided to apply the provided opts after the hardcoded `--recursive` and `--branch` flags, making it possible to override those flags from outside (although I don't think it will be a frequent usage pattern)