### PR TITLE
rsync output

### DIFF
--- a/command/file_test.go
+++ b/command/file_test.go
@@ -12,6 +12,6 @@ func TestCopyFileErrorIfDirectory(t *testing.T) {
 	{
 		tmpFolder, err := pathutil.NormalizedOSTempDirPath("_tmp")
 		require.NoError(t, err)
-		require.EqualError(t, CopyFile(tmpFolder, "./nothing/whatever"), "Source is a directory: "+tmpFolder)
+		require.EqualError(t, CopyFile(tmpFolder, "./nothing/whatever"), "source is a directory: "+tmpFolder)
 	}
 }


### PR DESCRIPTION
This PR stops rsync printing directly to the standard output.

This is needed because the Bitrise CLI uses `CopyFile` and `CopyDir` functions for activating local Steps.
When rsync fails, it directly prints an error to the stdout, which messes up the CLI's structured logging.