### PR TITLE
Removed log for download url

### DIFF
--- a/filedownloader/filedownloader.go
+++ b/filedownloader/filedownloader.go
@@ -46,7 +46,6 @@ func (downloader FileDownloader) GetWithFallback(destination, source string, fal
 		if err != nil {
 			log.Errorf("Could not download file from: %s", err)
 		} else {
-			log.Infof("URL used to download file: %s", source)
 			return nil
 		}
 	}

--- a/filedownloader/filedownloader.go
+++ b/filedownloader/filedownloader.go
@@ -44,7 +44,7 @@ func (downloader FileDownloader) GetWithFallback(destination, source string, fal
 	for _, source := range sources {
 		err := downloader.Get(destination, source)
 		if err != nil {
-			log.Errorf("Could not download file from: %s", err)
+			log.Warnf("Could not download file (%s): %s", source, err)
 		} else {
 			return nil
 		}


### PR DESCRIPTION
## Context
[[CI-688](https://bitrise.atlassian.net/browse/CI-688)] We want to reduce clutter in the build log when using the deploy-to-bitrise-io Step.

## Changes
* Removed logging the URL in `filedownloader` package when downloading a file.
* Update logging for error scenario where download fails for a URL.

[CI-688]: https://bitrise.atlassian.net/browse/CI-688?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ