### PR TITLE
755 permissions when creating directory

### DIFF
--- a/pathutil/pathutil.go
+++ b/pathutil/pathutil.go
@@ -44,7 +44,7 @@ func UserHomeDir() string {
 func EnsureDirExist(dir string) error {
 	exist, err := IsDirExists(dir)
 	if !exist || err != nil {
-		return os.MkdirAll(dir, 0777)
+		return os.MkdirAll(dir, 0755)
 	}
 	return nil
 }


### PR DESCRIPTION
## Context
\[[CI-763](https://bitrise.atlassian.net/browse/CI-763)\] Stripe pointed out that our plugin executables have `777` permissions which was triggering their security scanner and suggested us to change permissions to `755`.

We also thought why not change the directory permissions to 755 to be on the safe side as a proactive security measure. 

## Investigation
We found that directories already have `755` permission, but we don’t know how :flushed:

Upon further inspection we found from the bitrise-cli we are calling the `EnsureDirExist` in `pathutil.go` which calls `os.MkdirAll(dir, 0777)` so we’re explicitly saying to use `777` permission, but the `~/.bitrise` directory is still being created with `755` permission.

We thought there was something happening during the image creation process, but it turns out it’s due to `umask` that the folder permissions are defaulting to `755`.

## Decisions
We decided to avoid setting the umask using `syscall.Umask()` and instead just set the file permissions here. This will not have much of an affect since the directories are already set with `755` permissions, but we want to be explicit about it.