### PR TITLE
File manager

### DIFF
--- a/fileutil/fileutil.go
+++ b/fileutil/fileutil.go
@@ -1,6 +1,9 @@
 package fileutil
 
 import (
+	"errors"
+	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 )
@@ -8,6 +11,7 @@ import (
 // FileManager ...
 type FileManager interface {
 	Open(path string) (*os.File, error)
+	OpenReaderIfExists(path string) (io.Reader, error)
 	Remove(path string) error
 	RemoveAll(path string) error
 	Write(path string, value string, perm os.FileMode) error
@@ -25,6 +29,20 @@ func NewFileManager() FileManager {
 // Open ...
 func (fileManager) Open(path string) (*os.File, error) {
 	return os.Open(path)
+}
+
+// OpenReaderIfExists opens the named file using os.Open and returns an io.Reader.
+// An ErrNotExist error is absorbed and the returned io.Reader will be nil,
+// other errors from os.Open are returned as is.
+func (fileManager) OpenReaderIfExists(path string) (io.Reader, error) {
+	file, err := os.Open(path)
+	if errors.Is(err, fs.ErrNotExist) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return file, nil
 }
 
 // Remove ...

--- a/fileutil/fileutil.go
+++ b/fileutil/fileutil.go
@@ -12,6 +12,7 @@ import (
 type FileManager interface {
 	Open(path string) (*os.File, error)
 	OpenReaderIfExists(path string) (io.Reader, error)
+	ReadDirEntryNames(path string) ([]string, error)
 	Remove(path string) error
 	RemoveAll(path string) error
 	Write(path string, value string, perm os.FileMode) error
@@ -24,6 +25,19 @@ type fileManager struct {
 // NewFileManager ...
 func NewFileManager() FileManager {
 	return fileManager{}
+}
+
+// ReadDirEntryNames reads the named directory using os.ReadDir and returns the dir entries' names.
+func (fileManager) ReadDirEntryNames(path string) ([]string, error) {
+	entries, err := os.ReadDir(path)
+	if err != nil {
+		return nil, err
+	}
+	var names []string
+	for _, entry := range entries {
+		names = append(names, entry.Name())
+	}
+	return names, nil
 }
 
 // Open ...


### PR DESCRIPTION
This PR adds `OpenReaderIfExists` and `ReadDirEntryNames` to `fileutil.FileManager`.

**OpenReaderIfExists**

Can be used to obtain an `io.Reader` for a file. There were two motivations behind this function:
1,  make file existence test easier:

with the stdlib:

```
f, err := os.Open(pth)
if err != nil {
  if os.IsNotExist(err) {
    // file doesn't exist
  } else {
    // other error
  }
}
```

with OpenReaderIfExists:

```
r, err := filemanager.OpenReaderIfExists(pth)
if err != nil {
   // other error
}
if r == nil {
   // file doesn't exist
}
```

2, Make testing easier:

```
filemanager := new(mocks.FileManager)
filemanager.On("OpenFile", "<SOME_PATH>").Return(strings.NewReader(<MOCK_CONTENT>), nil)
```

**ReadDirEntryNames**

Supports mocking `os.ReadDir`.