### PR TITLE
Return original command error in error tree

### DIFF
--- a/command/command.go
+++ b/command/command.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/bitrise-io/go-utils/v2/env"
+	"github.com/bitrise-io/go-utils/v2/errorutil"
 )
 
 // ErrorFinder ...
@@ -169,10 +170,11 @@ func printableCommandArgs(isQuoteFirst bool, fullCommandArgs []string) string {
 func (c command) wrapError(err error) error {
 	var exitErr *exec.ExitError
 	if errors.As(err, &exitErr) {
+		origErr := errorutil.NewHiddenOriginalError(err)
 		if c.errorCollector != nil && len(c.errorCollector.errorLines) > 0 {
-			return fmt.Errorf("command failed with exit status %d (%s): %w", exitErr.ExitCode(), c.PrintableCommandArgs(), errors.New(strings.Join(c.errorCollector.errorLines, "\n")))
+			return fmt.Errorf("command failed with exit status %d (%s): %w %w", exitErr.ExitCode(), c.PrintableCommandArgs(), errors.New(strings.Join(c.errorCollector.errorLines, "\n")), origErr)
 		}
-		return fmt.Errorf("command failed with exit status %d (%s): %w", exitErr.ExitCode(), c.PrintableCommandArgs(), errors.New("check the command's output for details"))
+		return fmt.Errorf("command failed with exit status %d (%s): %w %w", exitErr.ExitCode(), c.PrintableCommandArgs(), errors.New("check the command's output for details"), origErr)
 	}
 	return fmt.Errorf("executing command failed (%s): %w", c.PrintableCommandArgs(), err)
 }

--- a/command/command.go
+++ b/command/command.go
@@ -171,7 +171,7 @@ func (c command) wrapError(err error) error {
 	if errors.As(err, &exitErr) {
 		origErr := errorutil.NewHiddenOriginalError(err)
 		if c.errorCollector != nil && len(c.errorCollector.errorLines) > 0 {
-			return fmt.Errorf("command failed with exit status %d (%s): %w %w", exitErr.ExitCode(), c.PrintableCommandArgs(), errors.New(strings.Join(c.errorCollector.errorLines, "\n")), origErr)
+			return fmt.Errorf("command failed with exit status %d (%s): %w%w", exitErr.ExitCode(), c.PrintableCommandArgs(), errors.New(strings.Join(c.errorCollector.errorLines, "\n")), origErr)
 		}
 		return fmt.Errorf("command failed with exit status %d (%s): %w %w", exitErr.ExitCode(), c.PrintableCommandArgs(), errors.New("check the command's output for details"), origErr)
 	}

--- a/errorutil/hiddenerror.go
+++ b/errorutil/hiddenerror.go
@@ -1,0 +1,19 @@
+package errorutil
+
+type HiddenOriginalError struct {
+	originalErr error
+}
+
+func NewHiddenOriginalError(originalErr error) *HiddenOriginalError {
+	return &HiddenOriginalError{
+		originalErr: originalErr,
+	}
+}
+
+func (h HiddenOriginalError) Error() string {
+	return ""
+}
+
+func (h HiddenOriginalError) Unwrap() error {
+	return h.originalErr
+}

--- a/errorutil/hiddenerror.go
+++ b/errorutil/hiddenerror.go
@@ -1,19 +1,25 @@
 package errorutil
 
+// HiddenOriginalError allows to include an error in the error chain but do not print it.
+// this allows replacing it with a more readable error message,
+// while allowing code to check for the type of the error
 type HiddenOriginalError struct {
 	originalErr error
 }
 
+// NewHiddenOriginalError ...
 func NewHiddenOriginalError(originalErr error) *HiddenOriginalError {
 	return &HiddenOriginalError{
 		originalErr: originalErr,
 	}
 }
 
+// Error ...
 func (h HiddenOriginalError) Error() string {
 	return ""
 }
 
+// Unwrap ...
 func (h HiddenOriginalError) Unwrap() error {
 	return h.originalErr
 }


### PR DESCRIPTION
Shove the original command error in the error tree. This allows checking for the specific exit code by code like this:
```
	var exitError *exec.ExitError
	if errors.As(err, &exitError) {
```
wrapError did not do this, breaking code expecting the above to work. This is fixed by using a feature in go 1.20 that allows wrapping multiple errors. (https://tip.golang.org/doc/go1.20#errors)


Output on go >= 1.20:
```
Run: failed to shutdown Simulator, command execution failed: command failed with exit status 149 (xcrun "simctl" "shutdown" "216F1ECE-9545-4CDD-A706-199C432EA348"): check the command's output for details 
````

Output on go < 1.20:
```
Run: failed to shutdown Simulator, command execution failed: command failed with exit status 149 (xcrun "simctl" "shutdown" "D519202A-FCD1-496C-AFCC-134697A128C8"): check the command's output for details %!w(*errorutil.HiddenOriginalError=&{0x140000e67a0})
```