### PR TITLE
[CI-2225] Use different parameter quoting

### DIFF
--- a/command/command.go
+++ b/command/command.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"os/exec"
-	"strconv"
 	"strings"
 
 	"github.com/bitrise-io/go-utils/v2/env"
@@ -156,7 +155,7 @@ func (c command) Wait() error {
 func printableCommandArgs(isQuoteFirst bool, fullCommandArgs []string) string {
 	var cmdArgsDecorated []string
 	for idx, anArg := range fullCommandArgs {
-		quotedArg := strconv.Quote(anArg)
+		quotedArg := fmt.Sprintf("\"%s\"", anArg)
 		if idx == 0 && !isQuoteFirst {
 			quotedArg = anArg
 		}

--- a/command/command_test.go
+++ b/command/command_test.go
@@ -2,11 +2,13 @@ package command
 
 import (
 	"bytes"
+	"fmt"
 	"os/exec"
 	"strings"
 	"testing"
 
 	"github.com/bitrise-io/go-utils/v2/env"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestRunErrors(t *testing.T) {
@@ -236,4 +238,14 @@ Error: fourth error`,
 			}
 		})
 	}
+}
+
+func TestSpecialCharactersAreNotEscaped(t *testing.T) {
+	programName := "test"
+	argument := `-----BEGIN PRIVATE KEY-----\nThis\nis\na\nprivate-key\n-----END PRIVATE KEY-----`
+
+	got := NewFactory(env.NewRepository()).Create(programName, []string{argument}, nil).PrintableCommandArgs()
+	expected := fmt.Sprintf("%s \"%s\"", programName, argument)
+
+	assert.Equal(t, expected, got)
 }


### PR DESCRIPTION
This PR will replace the `strconv.Quote` with simple string concatenation because the `strconv.Quote` function also escapes the string which was not our intention.