### PR TITLE
[CI-2225] Use different parameter quoting

### DIFF
--- a/command/command.go
+++ b/command/command.go
@@ -2,10 +2,10 @@ package command
 
 import (
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"os/exec"
-	"strconv"
 	"strings"
 )
 
@@ -125,7 +125,7 @@ func (m Model) PrintableCommandArgs() string {
 func PrintableCommandArgs(isQuoteFirst bool, fullCommandArgs []string) string {
 	cmdArgsDecorated := []string{}
 	for idx, anArg := range fullCommandArgs {
-		quotedArg := strconv.Quote(anArg)
+		quotedArg := fmt.Sprintf("\"%s\"", anArg)
 		if idx == 0 && !isQuoteFirst {
 			quotedArg = anArg
 		}

--- a/command/command_test.go
+++ b/command/command_test.go
@@ -1,10 +1,12 @@
 package command_test
 
 import (
+	"fmt"
 	"os/exec"
 	"testing"
 
 	"github.com/bitrise-io/go-utils/command"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -105,4 +107,17 @@ func TestRunCmdAndReturnExitCode(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestSpecialCharactersAreNotEscaped(t *testing.T) {
+	programName := "test"
+	argument := `-----BEGIN PRIVATE KEY-----\nThis\nis\na\nprivate-key\n-----END PRIVATE KEY-----`
+
+	cmd, err := command.NewWithParams(programName, argument)
+	require.NoError(t, err)
+
+	got := cmd.PrintableCommandArgs()
+	expected := fmt.Sprintf("%s \"%s\"", programName, argument)
+
+	assert.Equal(t, expected, got)
 }


### PR DESCRIPTION
This PR will replace the strconv.Quote with simple string concatenation because the strconv.Quote function also escapes the string which was not our intention.