### PR TITLE
[CI-2304] Spinner output configuration

### DIFF
--- a/progress/spinner.go
+++ b/progress/spinner.go
@@ -35,10 +35,14 @@ func NewSpinner(message string, chars []string, delay time.Duration, writer io.W
 
 // NewDefaultSpinner ...
 func NewDefaultSpinner(message string) Spinner {
+	return NewDefaultSpinnerWithOutput(message, os.Stdout)
+}
+
+// NewDefaultSpinnerWithOutput ...
+func NewDefaultSpinnerWithOutput(message string, output io.Writer) Spinner {
 	chars := []string{"⣾", "⣽", "⣻", "⢿", "⡿", "⣟", "⣯", "⣷"}
 	delay := 100 * time.Millisecond
-	writer := os.Stdout
-	return NewSpinner(message, chars, delay, writer)
+	return NewSpinner(message, chars, delay, output)
 }
 
 func (s *Spinner) erase() {

--- a/progress/wrapper.go
+++ b/progress/wrapper.go
@@ -2,6 +2,7 @@ package progress
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"strings"
 
@@ -26,6 +27,13 @@ func NewWrapper(spinner Spinner, interactiveMode bool) Wrapper {
 // NewDefaultWrapper ...
 func NewDefaultWrapper(message string) Wrapper {
 	spinner := NewDefaultSpinner(message)
+	interactiveMode := OutputDeviceIsTerminal()
+	return NewWrapper(spinner, interactiveMode)
+}
+
+// NewDefaultWrapperWithOutput ...
+func NewDefaultWrapperWithOutput(message string, output io.Writer) Wrapper {
+	spinner := NewDefaultSpinnerWithOutput(message, output)
 	interactiveMode := OutputDeviceIsTerminal()
 	return NewWrapper(spinner, interactiveMode)
 }

--- a/progress/wrapper_test.go
+++ b/progress/wrapper_test.go
@@ -1,10 +1,16 @@
+//go:build !race
 // +build !race
 
 package progress
 
 import (
+	"bytes"
+	"fmt"
+	"io"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestNewWrapper(t *testing.T) {
@@ -22,4 +28,17 @@ func TestNewDefaultWrapper(t *testing.T) {
 	NewDefaultWrapper(message).WrapAction(func() {
 		time.Sleep(2 * time.Second)
 	})
+}
+
+func TestNewDefaultWrapperWithOutput(t *testing.T) {
+	message := "loading"
+
+	var b bytes.Buffer
+	NewDefaultWrapperWithOutput(message, io.Writer(&b)).WrapAction(func() {
+		time.Sleep(2 * time.Second)
+	})
+
+	expected := fmt.Sprintf("%s...\n", message)
+	got := b.String()
+	assert.Equal(t, expected, got)
 }


### PR DESCRIPTION
The self hosted agent setup uncovered a path in the CLI where it was not using structured logging but instead was writing directly to the stdout. The build log grouping service was receiving such content:
```
[
   ...
   {
      "timestamp":"2023-12-04T16:15:17.7254-06:00",
      "type":"log",
      "producer":"bitrise_cli",
      "level":"normal",
      "message":"You can find more information about stepman on its official GitHub page: https://github.com/bitrise-io/stepman\n"
   },
   "Installing...",
   {
      "timestamp":"2023-12-04T16:15:18.233691-06:00",
      "type":"log",
      "producer":"bitrise_cli",
      "level":"normal",
      "message":"\u001b[32;1m[OK]\u001b[0m stepman (0.16.1): /Users/foreflight/.bitrise/tools/stepman\n"
   },
   ...
]
```
where the `Installing...` message is not wrapped into a json object. The root cause of it was the spinner component which was writing directly to the stdout. 

After these changes the component generates correct json output:
```
{"timestamp":"2023-12-05T15:21:52.645225Z","type":"log","producer":"bitrise_cli","level":"normal","message":"Installing...\n"}
```

I have created a new initialiser which accepts an `io.Writer` which will be used as the destination. 