### PR TITLE
Add response body to log

### DIFF
--- a/filedownloader/filedownloader.go
+++ b/filedownloader/filedownloader.go
@@ -108,7 +108,10 @@ func download(context context.Context, client HTTPClient, source string, destina
 	}()
 
 	if resp.StatusCode != http.StatusOK {
-		responseBodyBytes, _ := io.ReadAll(resp.Body)
+		responseBodyBytes, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return fmt.Errorf("unable to download file from: %s. Status code: %d", source, resp.StatusCode)
+		}
 		return fmt.Errorf("unable to download file from: %s. Status code: %d. Response body: %s", source, resp.StatusCode, string(responseBodyBytes))
 	}
 

--- a/filedownloader/filedownloader.go
+++ b/filedownloader/filedownloader.go
@@ -108,7 +108,8 @@ func download(context context.Context, client HTTPClient, source string, destina
 	}()
 
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("unable to download file from: %s. Status code: %d", source, resp.StatusCode)
+		responseBodyBytes, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("unable to download file from: %s. Status code: %d. Response body: %s", source, resp.StatusCode, string(responseBodyBytes))
 	}
 
 	if _, err = io.Copy(destination, resp.Body); err != nil {

--- a/filedownloader/filedownloader.go
+++ b/filedownloader/filedownloader.go
@@ -109,11 +109,9 @@ func download(context context.Context, client HTTPClient, source string, destina
 	}()
 
 	if resp.StatusCode != http.StatusOK {
-		if resp.Body != nil {
-			responseBytes, err := httputil.DumpResponse(resp, true)
-			if err == nil {
-				return fmt.Errorf("unable to download file from: %s. Status code: %d. Response: %s", source, resp.StatusCode, string(responseBytes))
-			}
+		responseBytes, err := httputil.DumpResponse(resp, true)
+		if err == nil {
+			return fmt.Errorf("unable to download file from: %s. Status code: %d. Response: %s", source, resp.StatusCode, string(responseBytes))
 		}
 		return fmt.Errorf("unable to download file from: %s. Status code: %d", source, resp.StatusCode)
 	}

--- a/filedownloader/filedownloader_test.go
+++ b/filedownloader/filedownloader_test.go
@@ -41,7 +41,7 @@ func Test_get_InvalidStatusCode_NoBody(t *testing.T) {
 	path := givenTempPath(t)
 	url := "http://url.com"
 	statusCode := 404
-	expectedErr := fmt.Errorf("unable to download file from: %s. Status code: %d. Response: HTTP/0.0 404 Not Found\r\nContent-Length: 0\r\n\r\n", url, statusCode)
+	expectedErrString := fmt.Sprintf("unable to download file from: %s. Status code: %d. Response: HTTP/0.0 404 Not Found\r\nContent-Length: 0\r\n\r\n", url, statusCode)
 	mockedHTTPClient := givenHTTPClient(
 		http.Response{
 			StatusCode: statusCode,
@@ -52,7 +52,7 @@ func Test_get_InvalidStatusCode_NoBody(t *testing.T) {
 	err := downloader.Get(path, url)
 
 	// Then
-	require.Equal(t, expectedErr, err)
+	require.Equal(t, errors.New(expectedErrString).Error(), err.Error())
 	assertFileNotExists(t, path)
 }
 

--- a/filedownloader/filedownloader_test.go
+++ b/filedownloader/filedownloader_test.go
@@ -41,7 +41,7 @@ func Test_get_InvalidStatusCode_NoBody(t *testing.T) {
 	path := givenTempPath(t)
 	url := "http://url.com"
 	statusCode := 404
-	expectedErr := fmt.Errorf("unable to download file from: %s. Status code: %d", url, statusCode)
+	expectedErr := fmt.Errorf("unable to download file from: %s. Status code: %d. Response: HTTP/0.0 404 Not Found\r\nContent-Length: 0\r\n\r\n", url, statusCode)
 	mockedHTTPClient := givenHTTPClient(
 		http.Response{
 			StatusCode: statusCode,

--- a/filedownloader/filedownloader_test.go
+++ b/filedownloader/filedownloader_test.go
@@ -3,6 +3,7 @@ package filedownloader
 import (
 	"errors"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -35,7 +36,7 @@ func Test_get_Success(t *testing.T) {
 	assertFileContent(t, path, "filecontent1")
 }
 
-func Test_get_InvalidStatusCode(t *testing.T) {
+func Test_get_InvalidStatusCode_NoBody(t *testing.T) {
 	// Given
 	path := givenTempPath(t)
 	url := "http://url.com"
@@ -44,6 +45,28 @@ func Test_get_InvalidStatusCode(t *testing.T) {
 	mockedHTTPClient := givenHTTPClient(
 		http.Response{
 			StatusCode: statusCode,
+		})
+	downloader := givenFileDownloader(mockedHTTPClient)
+
+	// When
+	err := downloader.Get(path, url)
+
+	// Then
+	require.Equal(t, expectedErr, err)
+	assertFileNotExists(t, path)
+}
+
+func Test_get_InvalidStatusCode_WithBody(t *testing.T) {
+	// Given
+	path := givenTempPath(t)
+	url := "http://url.com"
+	statusCode := 404
+	expectedErr := fmt.Errorf("unable to download file from: %s. Status code: %d. Response: HTTP/0.0 404 Not Found\r\ntest-header: test-header-value\r\n\r\ntest-body", url, statusCode)
+	mockedHTTPClient := givenHTTPClient(
+		http.Response{
+			StatusCode: statusCode,
+			Header:     http.Header{"test-header": []string{"test-header-value"}},
+			Body:       io.NopCloser(strings.NewReader("test-body")),
 		})
 	downloader := givenFileDownloader(mockedHTTPClient)
 


### PR DESCRIPTION
This PR adds http response dump to the log in case of a network failure to further support debugging.