### PR TITLE
Increment the waitgroup first

### DIFF
--- a/analytics/track.go
+++ b/analytics/track.go
@@ -43,8 +43,8 @@ func NewTracker(client Client, waitTimeout time.Duration, properties ...Properti
 func (t tracker) Enqueue(eventName string, properties ...Properties) {
 	var b bytes.Buffer
 	newEvent(eventName, append(t.properties, properties...)).toJSON(&b)
-	t.jobs <- &b
 	t.waitGroup.Add(1)
+	t.jobs <- &b
 }
 
 // Wait ...


### PR DESCRIPTION
Fix for a CLI crash where the worker finishes the job before we increment the WaitGroup.