### PR TITLE
Return ExitError type

### DIFF
--- a/command/command.go
+++ b/command/command.go
@@ -168,14 +168,14 @@ func printableCommandArgs(isQuoteFirst bool, fullCommandArgs []string) string {
 func (c command) wrapError(err error) error {
 	var exitErr *exec.ExitError
 	if errors.As(err, &exitErr) {
-		if c.errorCollector != nil && len(c.errorCollector.errorLines) > 0 {
-			reason := fmt.Errorf("command failed with exit status %d (%s): %w", exitErr.ExitCode(), c.PrintableCommandArgs(), errors.New(strings.Join(c.errorCollector.errorLines, "\n")))
-			return NewExitStatusError(reason, exitErr)
+		errorLines := []string{}
+		if c.errorCollector != nil {
+			errorLines = c.errorCollector.errorLines
 		}
 
-		reason := fmt.Errorf("command failed with exit status %d (%s): %w", exitErr.ExitCode(), c.PrintableCommandArgs(), errors.New("check the command's output for details"))
-		return NewExitStatusError(reason, exitErr)
+		return NewExitStatusError(c.PrintableCommandArgs(), exitErr, errorLines)
 	}
+
 	return fmt.Errorf("executing command failed (%s): %w", c.PrintableCommandArgs(), err)
 }
 

--- a/command/command_test.go
+++ b/command/command_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 
 	"github.com/bitrise-io/go-utils/v2/env"
-	"github.com/bitrise-io/go-utils/v2/errorutil"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -69,11 +68,6 @@ Error: fourth error`,
 			if gotErrMsg != tt.wantErr {
 				t.Errorf("command.Run() error = \n%v\n, wantErr \n%v\n", gotErrMsg, tt.wantErr)
 				return
-			}
-
-			gotFormattedMsg := errorutil.FormattedError(err)
-			if gotFormattedMsg != tt.wantErr {
-				t.Errorf("FormattedError() error = \n%v\n, wantErr \n%v\n", gotFormattedMsg, tt.wantErr)
 			}
 		})
 	}
@@ -199,10 +193,6 @@ Error: second error`,
 				t.Errorf("command.Run() error = %v, wantErr %v", gotErrMsg, tt.wantErr)
 				return
 			}
-			gotFormattedMsg := errorutil.FormattedError(err)
-			if gotFormattedMsg != tt.wantErr {
-				t.Errorf("FormattedError() error = \n%v\n, wantErr \n%v\n", gotFormattedMsg, tt.wantErr)
-			}
 		})
 	}
 }
@@ -258,10 +248,6 @@ Error: fourth error`,
 			if gotErrMsg != tt.wantErr {
 				t.Errorf("command.Run() error = %v, wantErr %v", gotErrMsg, tt.wantErr)
 				return
-			}
-			gotFormattedMsg := errorutil.FormattedError(err)
-			if gotFormattedMsg != tt.wantErr {
-				t.Errorf("FormattedError() error = \n%v\n, wantErr \n%v\n", gotFormattedMsg, tt.wantErr)
 			}
 		})
 	}

--- a/command/command_test.go
+++ b/command/command_test.go
@@ -199,6 +199,10 @@ Error: second error`,
 				t.Errorf("command.Run() error = %v, wantErr %v", gotErrMsg, tt.wantErr)
 				return
 			}
+			gotFormattedMsg := errorutil.FormattedError(err)
+			if gotFormattedMsg != tt.wantErr {
+				t.Errorf("FormattedError() error = \n%v\n, wantErr \n%v\n", gotFormattedMsg, tt.wantErr)
+			}
 		})
 	}
 }
@@ -254,6 +258,10 @@ Error: fourth error`,
 			if gotErrMsg != tt.wantErr {
 				t.Errorf("command.Run() error = %v, wantErr %v", gotErrMsg, tt.wantErr)
 				return
+			}
+			gotFormattedMsg := errorutil.FormattedError(err)
+			if gotFormattedMsg != tt.wantErr {
+				t.Errorf("FormattedError() error = \n%v\n, wantErr \n%v\n", gotFormattedMsg, tt.wantErr)
 			}
 		})
 	}

--- a/command/errors.go
+++ b/command/errors.go
@@ -1,5 +1,7 @@
 package command
 
+import "os/exec"
+
 // ExitStatusError ...
 type ExitStatusError struct {
 	readableReason     error
@@ -7,7 +9,7 @@ type ExitStatusError struct {
 }
 
 // NewExitStatusError ...
-func NewExitStatusError(reasonErr error, originalExitErr error) error {
+func NewExitStatusError(reasonErr error, originalExitErr *exec.ExitError) error {
 	if reasonErr.Error() == "" {
 		panic("reason must not be empty")
 	}

--- a/command/errors.go
+++ b/command/errors.go
@@ -18,16 +18,16 @@ func NewExitStatusError(reasonErr error, originalExitErr *exec.ExitError) error 
 }
 
 // Error returns the formatted error message. Does not include the original error message (`exit status 1`).
-func (c *ExitStatusError) Error() string {
-	return c.readableReason.Error()
+func (e *ExitStatusError) Error() string {
+	return e.readableReason.Error()
 }
 
 // Unwrap is needed for errors.Is and errors.As to work correctly.
-func (c *ExitStatusError) Unwrap() error {
-	return c.originalCommandErr
+func (e *ExitStatusError) Unwrap() error {
+	return e.originalCommandErr
 }
 
 // Reason returns the user-friendly error, to be used by errorutil.ErrorFormatter.
-func (c *ExitStatusError) Reason() error {
-	return c.readableReason
+func (e *ExitStatusError) Reason() error {
+	return e.readableReason
 }

--- a/command/errors.go
+++ b/command/errors.go
@@ -25,7 +25,7 @@ func (c *ExitStatusError) Unwrap() []error {
 	return []error{c.readableReason, c.originalCommandErr}
 }
 
-// Reason returns the user-friendly error message.
+// Reason returns the user-friendly error, to be used by errorutil.ErrorFormatter.
 func (c *ExitStatusError) Reason() error {
 	return c.readableReason
 }

--- a/command/errors.go
+++ b/command/errors.go
@@ -9,20 +9,24 @@ import (
 
 // ExitStatusError ...
 type ExitStatusError struct {
-	readableReason     error
-	originalCommandErr error
+	readableReason  error
+	originalExitErr error
 }
 
 // NewExitStatusError ...
 func NewExitStatusError(printableCmdArgs string, exitErr *exec.ExitError, errorLines []string) error {
 	reasonMsg := fmt.Sprintf("command failed with exit status %d (%s)", exitErr.ExitCode(), printableCmdArgs)
 	if len(errorLines) == 0 {
-		reasonErr := fmt.Errorf("%s: %w", reasonMsg, errors.New("check the command's output for details"))
-		return &ExitStatusError{readableReason: reasonErr, originalCommandErr: exitErr}
+		return &ExitStatusError{
+			readableReason:  fmt.Errorf("%s: %w", reasonMsg, errors.New("check the command's output for details")),
+			originalExitErr: exitErr,
+		}
 	}
 
-	reasonErr := fmt.Errorf("%s: %w", reasonMsg, errors.New(strings.Join(errorLines, "\n")))
-	return &ExitStatusError{readableReason: reasonErr, originalCommandErr: exitErr}
+	return &ExitStatusError{
+		readableReason:  fmt.Errorf("%s: %w", reasonMsg, errors.New(strings.Join(errorLines, "\n"))),
+		originalExitErr: exitErr,
+	}
 }
 
 // Error returns the formatted error message. Does not include the original error message (`exit status 1`).
@@ -32,7 +36,7 @@ func (e *ExitStatusError) Error() string {
 
 // Unwrap is needed for errors.Is and errors.As to work correctly.
 func (e *ExitStatusError) Unwrap() error {
-	return e.originalCommandErr
+	return e.originalExitErr
 }
 
 // Reason returns the user-friendly error, to be used by errorutil.ErrorFormatter.

--- a/command/errors.go
+++ b/command/errors.go
@@ -1,0 +1,31 @@
+package command
+
+// ExitStatusError ...
+type ExitStatusError struct {
+	readableReason     error
+	originalCommandErr error
+}
+
+// NewExitStatusError ...
+func NewExitStatusError(reasonErr error, originalExitErr error) error {
+	if reasonErr.Error() == "" {
+		panic("reason must not be empty")
+	}
+
+	return &ExitStatusError{readableReason: reasonErr, originalCommandErr: originalExitErr}
+}
+
+// Error returns the formatted error message. Does not include the original error message (`exit status 1`).
+func (c *ExitStatusError) Error() string {
+	return c.readableReason.Error()
+}
+
+// Unwrap is needed for errors.Is and errors.As to work correctly.
+func (c *ExitStatusError) Unwrap() []error {
+	return []error{c.readableReason, c.originalCommandErr}
+}
+
+// Reason returns the user-friendly error message.
+func (c *ExitStatusError) Reason() error {
+	return c.readableReason
+}

--- a/command/errors.go
+++ b/command/errors.go
@@ -23,8 +23,8 @@ func (c *ExitStatusError) Error() string {
 }
 
 // Unwrap is needed for errors.Is and errors.As to work correctly.
-func (c *ExitStatusError) Unwrap() []error {
-	return []error{c.readableReason, c.originalCommandErr}
+func (c *ExitStatusError) Unwrap() error {
+	return c.originalCommandErr
 }
 
 // Reason returns the user-friendly error, to be used by errorutil.ErrorFormatter.

--- a/errorutil/formatted_error.go
+++ b/errorutil/formatted_error.go
@@ -16,8 +16,7 @@ func FormattedError(err error) string {
 		i++
 
 		// Use the user-friendly error message, ignore the original exec.ExitError.
-		var commandExitStatusError *command.ExitStatusError
-		if errors.As(err, &commandExitStatusError) {
+		if commandExitStatusError, ok := err.(*command.ExitStatusError); ok {
 			err = commandExitStatusError.Reason()
 		}
 

--- a/errorutil/formatted_error.go
+++ b/errorutil/formatted_error.go
@@ -3,6 +3,8 @@ package errorutil
 import (
 	"errors"
 	"strings"
+
+	"github.com/bitrise-io/go-utils/v2/command"
 )
 
 // FormattedError ...
@@ -13,8 +15,13 @@ func FormattedError(err error) string {
 	for {
 		i++
 
-		reason := err.Error()
+		// Use the user-friendly error message, ignore the original exec.ExitError.
+		var commandExitStatusError *command.ExitStatusError
+		if errors.As(err, &commandExitStatusError) {
+			err = commandExitStatusError.Reason()
+		}
 
+		reason := err.Error()
 		if err = errors.Unwrap(err); err == nil {
 			formatted = appendError(formatted, reason, i, true)
 			return formatted

--- a/errorutil/formatted_error_test.go
+++ b/errorutil/formatted_error_test.go
@@ -76,7 +76,7 @@ func TestFormattedErrorWithCommand(t *testing.T) {
 		wantMsg string
 	}{
 		{
-			name: "command without stdout set",
+			name: "command error",
 			cmdFn: func() error {
 				cmd := commandFactory.Create("bash", []string{"../command/testdata/exit_with_message.sh"}, nil)
 				return cmd.Run()
@@ -84,6 +84,20 @@ func TestFormattedErrorWithCommand(t *testing.T) {
 			wantErr: `command failed with exit status 1 (bash "../command/testdata/exit_with_message.sh"): check the command's output for details`,
 			wantMsg: `command failed with exit status 1 (bash "../command/testdata/exit_with_message.sh"):
   check the command's output for details`,
+		},
+		{
+			name: "command error, wrapped",
+			cmdFn: func() error {
+				cmd := commandFactory.Create("bash", []string{"../command/testdata/exit_with_message.sh"}, nil)
+				if err := cmd.Run(); err != nil {
+					return fmt.Errorf("wrapped: %w", err)
+				}
+				return nil
+			},
+			wantErr: `wrapped: command failed with exit status 1 (bash "../command/testdata/exit_with_message.sh"): check the command's output for details`,
+			wantMsg: `wrapped:
+  command failed with exit status 1 (bash "../command/testdata/exit_with_message.sh"):
+    check the command's output for details`,
 		},
 		{
 			name: "command with error finder",

--- a/errorutil/formatted_error_test.go
+++ b/errorutil/formatted_error_test.go
@@ -3,7 +3,12 @@ package errorutil
 import (
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
+
+	"github.com/bitrise-io/go-utils/v2/command"
+	"github.com/bitrise-io/go-utils/v2/env"
+	"github.com/stretchr/testify/require"
 )
 
 func TestFormattedError(t *testing.T) {
@@ -56,6 +61,78 @@ func TestFormattedError(t *testing.T) {
 
 			if formatted != tt.wantFormattedError {
 				t.Errorf("got formatted error = %s, want %s", formatted, tt.wantFormattedError)
+			}
+		})
+	}
+}
+
+func TestRunErrors(t *testing.T) {
+	commandFactory := command.NewFactory(env.NewRepository())
+
+	tests := []struct {
+		name    string
+		cmdFn   func() error
+		wantErr string
+		wantMsg string
+	}{
+		{
+			name: "command without stdout set",
+			cmdFn: func() error {
+				cmd := commandFactory.Create("bash", []string{"../command/testdata/exit_with_message.sh"}, nil)
+				return cmd.Run()
+			},
+			wantErr: `command failed with exit status 1 (bash "../command/testdata/exit_with_message.sh"): check the command's output for details`,
+			wantMsg: `command failed with exit status 1 (bash "../command/testdata/exit_with_message.sh"):
+  check the command's output for details`,
+		},
+		{
+			name: "command with error finder",
+			cmdFn: func() error {
+				errorFinder := func(out string) []string {
+					var errors []string
+					for _, line := range strings.Split(out, "\n") {
+						if strings.Contains(line, "Error:") {
+							errors = append(errors, line)
+						}
+					}
+					return errors
+				}
+
+				cmd := commandFactory.Create("bash", []string{"../command/testdata/exit_with_message.sh"}, &command.Opts{
+					ErrorFinder: errorFinder,
+				})
+
+				err := cmd.Run()
+				return err
+			},
+			wantErr: `command failed with exit status 1 (bash "../command/testdata/exit_with_message.sh"): Error: first error
+Error: second error
+Error: third error
+Error: fourth error`,
+			wantMsg: `command failed with exit status 1 (bash "../command/testdata/exit_with_message.sh"):
+  Error: first error
+  Error: second error
+  Error: third error
+  Error: fourth error`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.cmdFn()
+
+			var gotErrMsg string
+			if err != nil {
+				gotErrMsg = err.Error()
+			}
+			if gotErrMsg != tt.wantErr {
+				t.Errorf("command.Run() error = \n%v\n, wantErr \n%v\n", gotErrMsg, tt.wantErr)
+				return
+			}
+
+			gotFormattedMsg := FormattedError(err)
+			require.Equal(t, tt.wantMsg, gotFormattedMsg, "FormattedError() error = \n%v\n, wantErr \n%v\n", gotFormattedMsg, tt.wantErr)
+			if gotFormattedMsg != tt.wantMsg {
+				t.Errorf("FormattedError() error = \n%v\n, wantErr \n%v\n", gotFormattedMsg, tt.wantErr)
 			}
 		})
 	}

--- a/errorutil/formatted_error_test.go
+++ b/errorutil/formatted_error_test.go
@@ -76,7 +76,7 @@ func TestFormattedErrorWithCommand(t *testing.T) {
 		wantMsg string
 	}{
 		{
-			name: "command error",
+			name: "command exit status error",
 			cmdFn: func() error {
 				cmd := commandFactory.Create("bash", []string{"../command/testdata/exit_with_message.sh"}, nil)
 				return cmd.Run()
@@ -84,6 +84,21 @@ func TestFormattedErrorWithCommand(t *testing.T) {
 			wantErr: `command failed with exit status 1 (bash "../command/testdata/exit_with_message.sh"): check the command's output for details`,
 			wantMsg: `command failed with exit status 1 (bash "../command/testdata/exit_with_message.sh"):
   check the command's output for details`,
+		},
+		{
+			name: "command execution failed, wrapped",
+			cmdFn: func() error {
+				cmd := commandFactory.Create("__notfoundinpath", []string{}, nil)
+				if err := cmd.Run(); err != nil {
+					return fmt.Errorf("wrapped: %w", err)
+				}
+				return nil
+			},
+			wantErr: `wrapped: executing command failed (__notfoundinpath): exec: "__notfoundinpath": executable file not found in $PATH`,
+			wantMsg: `wrapped:
+  executing command failed (__notfoundinpath):
+    exec: "__notfoundinpath":
+      executable file not found in $PATH`,
 		},
 		{
 			name: "command error, wrapped",

--- a/errorutil/formatted_error_test.go
+++ b/errorutil/formatted_error_test.go
@@ -66,7 +66,7 @@ func TestFormattedError(t *testing.T) {
 	}
 }
 
-func TestRunErrors(t *testing.T) {
+func TestFormattedErrorWithCommand(t *testing.T) {
 	commandFactory := command.NewFactory(env.NewRepository())
 
 	tests := []struct {


### PR DESCRIPTION
Shove the original command error in the error tree. This allows checking for the specific exit code by code like this:
```
	var exitError *exec.ExitError
	if errors.As(err, &exitError) {
```

Added command.FormattedError type to work around issue of not returning the original exec.ExitError type. The Unwrap() method returns the original error, so the above example will now work.