### PR TITLE
Add remote branch listing

### DIFF
--- a/command/git/commands.go
+++ b/command/git/commands.go
@@ -30,6 +30,11 @@ func (g *Git) CloneTagOrBranch(repo, tagOrBranch string, opts ...string) *comman
 	return g.command(args...)
 }
 
+// RemoteBranches lists all the remote branches.
+func (g *Git) RemoteBranches() *command.Model {
+	return g.command("ls-remote", "-b")
+}
+
 // RemoteList shows a list of existing remote urls with remote names.
 func (g *Git) RemoteList() *command.Model {
 	return g.command("remote", "-v")

--- a/command/git/commands_test.go
+++ b/command/git/commands_test.go
@@ -56,11 +56,15 @@ func TestGitCommands(t *testing.T) {
 		// Checkout
 		{
 			command: (&Git{}).Checkout("main"),
-			want:   `git "checkout" "main"`,
+			want:    `git "checkout" "main"`,
 		},
 		{
 			command: (&Git{}).Checkout("-B", "origin/main"),
-			want:   `git "checkout" "-B" "origin/main"`,
+			want:    `git "checkout" "-B" "origin/main"`,
+		},
+		{
+			command: (&Git{}).RemoteBranches(),
+			want:    `git "ls-remote" "-b"`,
 		},
 	}
 


### PR DESCRIPTION
Adds a new command which queries the remote repository directly. 

The previous implementation in the Git Clone step relies on a fetch + `git branch -r` combo but this is (especially the fetch part) time consuming in a large git repository. 

The `ls-remote` command is an old one but recently it received a soon to be breaking change. Previously the `--head` parameter had to be used to list branches but that is soft deprecated and will be completely removed soon. The new parameter is the `-b`. The Xcode 14 and Xcode 15 stacks have an older git version which does not know about the `-b` flag so it returns an error. Xcode 16 and the Linux stacks are fine. Soon we will have a new major Xcode stack so I think it is fine if this command returns an error on older stacks. This command will only drive a convince feature when the Git Clone step runs into an error.  