### PR TITLE
Handle BITRISE_ANALYTICS_DISABLED in step tracker

### DIFF
--- a/analytics/track.go
+++ b/analytics/track.go
@@ -2,10 +2,10 @@ package analytics
 
 import (
 	"bytes"
-	"os"
 	"sync"
 	"time"
 
+	"github.com/bitrise-io/go-utils/v2/env"
 	"github.com/bitrise-io/go-utils/v2/log"
 )
 
@@ -38,8 +38,8 @@ func (t noopTracker) Enqueue(eventName string, properties ...Properties) {}
 func (t noopTracker) Wait() {}
 
 // NewDefaultTracker ...
-func NewDefaultTracker(logger log.Logger, properties ...Properties) Tracker {
-	if os.Getenv(analyticsDisabledEnv) == "true" {
+func NewDefaultTracker(logger log.Logger, envRepo env.Repository, properties ...Properties) Tracker {
+	if envRepo.Get(analyticsDisabledEnv) == "true" {
 		return noopTracker{}
 	}
 	return NewTracker(NewDefaultClient(logger, asyncClientTimeout), timeout, properties...)

--- a/analytics/track_test.go
+++ b/analytics/track_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/bitrise-io/go-utils/v2/env"
 	"github.com/bitrise-io/go-utils/v2/mocks"
 
 	"github.com/stretchr/testify/mock"
@@ -132,7 +133,7 @@ func Test_tracker_WaitTimesOutOnBlockingClient(t *testing.T) {
 func Test_NewDefaultTracker_Disabled(t *testing.T) {
 	t.Setenv(analyticsDisabledEnv, "true")
 
-	tracker := NewDefaultTracker(new(mocks.Logger))
+	tracker := NewDefaultTracker(new(mocks.Logger), env.NewRepository())
 
 	if _, ok := tracker.(noopTracker); !ok {
 		t.Fatalf("expected noopTracker when %s is set", analyticsDisabledEnv)


### PR DESCRIPTION
### Context

This env var is already handled and respected in https://github.com/bitrise-io/bitrise and its tracker implementation, but not in the step-side tracker lib.

### Changes
- add noop tracker implementation
- default tracker checks `BITRISE_ANALYTICS_DISABLED` env var
- tests for disabling analytics