### PR TITLE
Add 'versions' package

### DIFF
--- a/versions/versions.go
+++ b/versions/versions.go
@@ -1,0 +1,98 @@
+package versions
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// CompareVersions ...
+// semantic version (X.Y.Z)
+// 1 if version 2 is greater then version 1, -1 if not
+// -2 & error if can't compare (if not supported component found)
+func CompareVersions(version1, version2 string) (int, error) {
+	version1Slice := strings.Split(version1, ".")
+	version2Slice := strings.Split(version2, ".")
+
+	lenDiff := len(version1Slice) - len(version2Slice)
+	if lenDiff != 0 {
+		makeDefVerComps := func(compLen int) []string {
+			comps := make([]string, compLen, compLen)
+			for idx := len(comps) - 1; idx >= 0; idx-- {
+				comps[idx] = "0"
+			}
+			return comps
+		}
+		if lenDiff > 0 {
+			// v1 slice is longer
+			version2Slice = append(version2Slice, makeDefVerComps(lenDiff)...)
+		} else {
+			// v2 slice is longer
+			version1Slice = append(version1Slice, makeDefVerComps(-lenDiff)...)
+		}
+	}
+
+	cnt := len(version1Slice)
+	for i, num := range version1Slice {
+		num1, err := strconv.ParseInt(num, 0, 64)
+		if err != nil {
+			return -2, fmt.Errorf("failed to parse int (%s): %s", num, err)
+		}
+
+		num2, err2 := strconv.ParseInt(version2Slice[i], 0, 64)
+		if err2 != nil {
+			return -2, fmt.Errorf("failed to parse int (%s): %s", version2Slice[i], err2)
+		}
+
+		if num2 > num1 {
+			return 1, nil
+		} else if num2 < num1 {
+			return -1, nil
+		}
+
+		if i == cnt-1 {
+			// last one
+			if num2 == num1 {
+				return 0, nil
+			}
+		}
+	}
+	return -1, nil
+}
+
+// IsVersionBetween ...
+//  returns true if it's between the lower and upper limit
+//  or in case it matches the lower or the upper limit
+func IsVersionBetween(verBase, verLower, verUpper string) (bool, error) {
+	r1, err := CompareVersions(verBase, verLower)
+	if err != nil {
+		return false, err
+	}
+	if r1 == 1 {
+		return false, nil
+	}
+
+	r2, err := CompareVersions(verBase, verUpper)
+	if err != nil {
+		return false, err
+	}
+	if r2 == -1 {
+		return false, nil
+	}
+
+	return true, nil
+}
+
+// IsVersionGreaterOrEqual ...
+//  returns true if verBase is greater or equal to verLower
+func IsVersionGreaterOrEqual(verBase, verLower string) (bool, error) {
+	r1, err := CompareVersions(verBase, verLower)
+	if err != nil {
+		return false, err
+	}
+	if r1 == 1 {
+		return false, nil
+	}
+
+	return true, nil
+}

--- a/versions/versions.go
+++ b/versions/versions.go
@@ -9,7 +9,7 @@ import (
 // CompareVersions ...
 // semantic version (X.Y.Z)
 // 1 if version 2 is greater then version 1, -1 if not
-// -2 & error if can't compare (if not supported component found)
+// -2 & error if can't compare (if not supported component found).
 func CompareVersions(version1, version2 string) (int, error) {
 	version1Slice := strings.Split(version1, ".")
 	version2Slice := strings.Split(version2, ".")
@@ -17,7 +17,7 @@ func CompareVersions(version1, version2 string) (int, error) {
 	lenDiff := len(version1Slice) - len(version2Slice)
 	if lenDiff != 0 {
 		makeDefVerComps := func(compLen int) []string {
-			comps := make([]string, compLen, compLen)
+			comps := make([]string, compLen)
 			for idx := len(comps) - 1; idx >= 0; idx-- {
 				comps[idx] = "0"
 			}
@@ -61,8 +61,9 @@ func CompareVersions(version1, version2 string) (int, error) {
 }
 
 // IsVersionBetween ...
-//  returns true if it's between the lower and upper limit
-//  or in case it matches the lower or the upper limit
+//
+//	returns true if it's between the lower and upper limit
+//	or in case it matches the lower or the upper limit.
 func IsVersionBetween(verBase, verLower, verUpper string) (bool, error) {
 	r1, err := CompareVersions(verBase, verLower)
 	if err != nil {
@@ -84,7 +85,8 @@ func IsVersionBetween(verBase, verLower, verUpper string) (bool, error) {
 }
 
 // IsVersionGreaterOrEqual ...
-//  returns true if verBase is greater or equal to verLower
+//
+//	returns true if verBase is greater or equal to verLower.
 func IsVersionGreaterOrEqual(verBase, verLower string) (bool, error) {
 	r1, err := CompareVersions(verBase, verLower)
 	if err != nil {

--- a/versions/versions_test.go
+++ b/versions/versions_test.go
@@ -1,0 +1,210 @@
+package versions
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCompareVersions(t *testing.T) {
+	res, err := CompareVersions("1.0.0", "1.0.1")
+	require.NoError(t, err)
+	require.Equal(t, 1, res, "Trivial compare")
+
+	res, err = CompareVersions("1.0.2", "1.0.1")
+	require.NoError(t, err)
+	require.Equal(t, -1, res, "Reverse compare")
+
+	res, err = CompareVersions("1.0.2", "1.0.2")
+	require.NoError(t, err)
+	require.Equal(t, 0, res, "Equal compare")
+
+	t.Log("1.0.0 <-> 0.9.8")
+	if res, err := CompareVersions("1.0.0", "0.9.8"); res != -1 || err != nil {
+		t.Fatal("Failed, res:", res, "| err:", err)
+	}
+	t.Log("0.9.8 <-> 1.0.0")
+	if res, err := CompareVersions("0.9.8", "1.0.0"); res != 1 || err != nil {
+		t.Fatal("Failed, res:", res, "| err:", err)
+	}
+
+	t.Log("Missing last num in first")
+	if res, err := CompareVersions("7.0", "7.0.2"); res != 1 || err != nil {
+		t.Fatal("Failed, res:", res, "| err:", err)
+	}
+	t.Log("Missing last num in first - eql")
+	if res, err := CompareVersions("7.0", "7.0.0"); res != 0 || err != nil {
+		t.Fatal("Failed, res:", res, "| err:", err)
+	}
+	t.Log("Missing last num in second")
+	if res, err := CompareVersions("7.0.2", "7.0"); res != -1 || err != nil {
+		t.Fatal("Failed, res:", res, "| err:", err)
+	}
+	t.Log("Missing last num in second - eql")
+	if res, err := CompareVersions("7.0.0", "7.0"); res != 0 || err != nil {
+		t.Fatal("Failed, res:", res, "| err:", err)
+	}
+	t.Log("Missing double-last num in first")
+	if res, err := CompareVersions("7", "7.0.2"); res != 1 || err != nil {
+		t.Fatal("Failed, res:", res, "| err:", err)
+	}
+	t.Log("Missing double-last num in first - eql")
+	if res, err := CompareVersions("7", "7.0.0"); res != 0 || err != nil {
+		t.Fatal("Failed, res:", res, "| err:", err)
+	}
+	t.Log("Missing double-last num in second")
+	if res, err := CompareVersions("7.0.2", "7"); res != -1 || err != nil {
+		t.Fatal("Failed, res:", res, "| err:", err)
+	}
+	t.Log("Missing double-last num in second - eql")
+	if res, err := CompareVersions("7.0.0", "7"); res != 0 || err != nil {
+		t.Fatal("Failed, res:", res, "| err:", err)
+	}
+
+	// specials are not handled but should not cause any issue / panic
+	t.Log("Special / non number component")
+	if res, err := CompareVersions("7.x.1.2.3", "7.0.1.x"); err == nil {
+		t.Fatal("Not supported compare should return an error!")
+	} else {
+		t.Log("[expected] Failed, res:", res, "| err:", err)
+	}
+}
+
+func TestIsVersionGreaterOrEqual(t *testing.T) {
+	t.Log("Yes - Trivial")
+	isGreaterOrEql, err := IsVersionGreaterOrEqual("1.1", "1.0")
+	if err != nil {
+		t.Fatal("Unexpected error:", err)
+	}
+	if !isGreaterOrEql {
+		t.Fatal("Invalid result")
+	}
+
+	t.Log("Yes - Trivial - eq")
+	isGreaterOrEql, err = IsVersionGreaterOrEqual("1.0", "1.0")
+	if err != nil {
+		t.Fatal("Unexpected error:", err)
+	}
+	if !isGreaterOrEql {
+		t.Fatal("Invalid result")
+	}
+
+	t.Log("No - Trivial")
+	isGreaterOrEql, err = IsVersionGreaterOrEqual("1.0", "1.1")
+	if err != nil {
+		t.Fatal("Unexpected error:", err)
+	}
+	if isGreaterOrEql {
+		t.Fatal("Invalid result")
+	}
+
+	t.Log("No - 1.0.0<->0.9.8")
+	isGreaterOrEql, err = IsVersionGreaterOrEqual("1.0.0", "0.9.8")
+	if err != nil {
+		t.Fatal("Unexpected error:", err)
+	}
+	if !isGreaterOrEql {
+		t.Fatal("Invalid result")
+	}
+
+	t.Log("No - 0.9.8<->1.0.0")
+	isGreaterOrEql, err = IsVersionGreaterOrEqual("0.9.8", "1.0.0")
+	if err != nil {
+		t.Fatal("Unexpected error:", err)
+	}
+	if isGreaterOrEql {
+		t.Fatal("Invalid result")
+	}
+
+	t.Log("Yes - bit more complex - eq")
+	isGreaterOrEql, err = IsVersionGreaterOrEqual("1.0.0", "1.0")
+	if err != nil {
+		t.Fatal("Unexpected error:", err)
+	}
+	if !isGreaterOrEql {
+		t.Fatal("Invalid result")
+	}
+
+	t.Log("Yes - bit more complex")
+	isGreaterOrEql, err = IsVersionGreaterOrEqual("1.0.1", "1.0")
+	if err != nil {
+		t.Fatal("Unexpected error:", err)
+	}
+	if !isGreaterOrEql {
+		t.Fatal("Invalid result")
+	}
+
+	t.Log("No - bit more complex")
+	isGreaterOrEql, err = IsVersionGreaterOrEqual("0.9.1", "1.0")
+	if err != nil {
+		t.Fatal("Unexpected error:", err)
+	}
+	if isGreaterOrEql {
+		t.Fatal("Invalid result")
+	}
+}
+
+func TestIsVersionBetween(t *testing.T) {
+	t.Log("Yes - Trivial")
+	isBetween, err := IsVersionBetween("1.1", "1.0", "1.2")
+	if err != nil {
+		t.Fatal("Unexpected error:", err)
+	}
+	if !isBetween {
+		t.Fatal("Invalid result")
+	}
+
+	t.Log("No - Trivial")
+	isBetween, err = IsVersionBetween("1.3", "1.0", "1.2")
+	if err != nil {
+		t.Fatal("Unexpected error:", err)
+	}
+	if isBetween {
+		t.Fatal("Invalid result")
+	}
+
+	t.Log("Yes - eq lower")
+	isBetween, err = IsVersionBetween("1.0", "1.0", "1.2")
+	if err != nil {
+		t.Fatal("Unexpected error:", err)
+	}
+	if !isBetween {
+		t.Fatal("Invalid result")
+	}
+
+	t.Log("Yes - eq upper")
+	isBetween, err = IsVersionBetween("1.2", "1.0", "1.2")
+	if err != nil {
+		t.Fatal("Unexpected error:", err)
+	}
+	if !isBetween {
+		t.Fatal("Invalid result")
+	}
+
+	t.Log("Yes - Bit more complex")
+	isBetween, err = IsVersionBetween("1.0.1", "1.0", "1.2")
+	if err != nil {
+		t.Fatal("Unexpected error:", err)
+	}
+	if !isBetween {
+		t.Fatal("Invalid result")
+	}
+
+	t.Log("Yes - Bit more complex - eq")
+	isBetween, err = IsVersionBetween("1.2.0", "1.0", "1.2")
+	if err != nil {
+		t.Fatal("Unexpected error:", err)
+	}
+	if !isBetween {
+		t.Fatal("Invalid result")
+	}
+
+	t.Log("No - Bit more complex")
+	isBetween, err = IsVersionBetween("1.2.1", "1.0", "1.2")
+	if err != nil {
+		t.Fatal("Unexpected error:", err)
+	}
+	if isBetween {
+		t.Fatal("Invalid result")
+	}
+}


### PR DESCRIPTION
These functions are mostly used by Bitrise repositories, for example the bitrise CLI itself.

These do not require any external dependencies so this implementation nearly matches the v1, there is no need to refactor it.