### PR TITLE
[STEP-2177] Add CopyOptions to FileManager CopyFile/CopyDir

### DIFF
--- a/.mockery.yml
+++ b/.mockery.yml
@@ -16,3 +16,6 @@ packages:
     interfaces:
       FileManager:
       OsProxy:
+        config:
+          dir: "{{.InterfaceDir}}/mocks/osproxy"
+          pkgname: osproxy

--- a/fileutil/copy.go
+++ b/fileutil/copy.go
@@ -12,15 +12,21 @@ import (
 )
 
 // CopyFile copies a single file from src to dst.
-func (fm fileManager) CopyFile(src, dst string) error {
+// Pass [CopyOptions] to modify default behavior as required, nil otherwise.
+//
+// Attention: the default behavior is different from the v1 implementation of `command.CopyFile`,
+// v1 function replaces the existing file.
+// By default, if the target file exists, this call will fail with an error.
+func (fm fileManager) CopyFile(src, dst string, opts *CopyOptions) error {
 	srcDir := filepath.Dir(src)
 	fsys := fm.osProxy.DirFS(srcDir)
 
-	return fm.copyFileFS(fsys, filepath.Base(src), dst)
+	return fm.copyFileFS(fsys, filepath.Base(src), dst, opts)
 }
 
-// CopyFileFS is the excerpt from fs.CopyFS that copies a single file from fs.FS to dst path.
-func (fm fileManager) copyFileFS(fsys fs.FS, src, dst string) error {
+// copyFileFS is the excerpt from fs.CopyFS that copies a single file from fs.FS to dst path.
+// The [CopyOptions] parameter is used to modify default behavior as required or keep the default when nil is provided.
+func (fm fileManager) copyFileFS(fsys fs.FS, src, dst string, opts *CopyOptions) error {
 	r, err := fsys.Open(src)
 	if err != nil {
 		return err
@@ -30,7 +36,11 @@ func (fm fileManager) copyFileFS(fsys fs.FS, src, dst string) error {
 	if err != nil {
 		return err
 	}
-	w, err := fm.osProxy.OpenFile(dst, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0777)
+	flags := os.O_CREATE | os.O_EXCL | os.O_WRONLY
+	if opts != nil && opts.Overwrite {
+		flags = os.O_CREATE | os.O_TRUNC | os.O_WRONLY
+	}
+	w, err := fm.osProxy.OpenFile(dst, flags, 0777)
 	if err != nil {
 		return err
 	}
@@ -65,9 +75,11 @@ func (fm fileManager) copyFileFS(fsys fs.FS, src, dst string) error {
 //
 // Preserves permissions and ownership when possible.
 //
-// CopyFS will not overwrite existing files. If a file name in fsys
+// By default, CopyFS will not overwrite existing files. If a file name in fsys
 // already exists in the destination, CopyFS will return an error
 // such that errors.Is(err, fs.ErrExist) will be true.
+// Attention: the default behavior is different from the v1 implementation of `command.CopyFile`,
+// v1 function replaces the existing files.
 //
 // Symbolic links in dir are followed.
 //
@@ -76,7 +88,7 @@ func (fm fileManager) copyFileFS(fsys fs.FS, src, dst string) error {
 //
 // Copying stops at and returns the first error encountered.
 // Note: symlinks are preserved during the copy operation
-func (fm fileManager) CopyDir(src, dst string) error {
+func (fm fileManager) CopyDir(src, dst string, opts *CopyOptions) error {
 	fsys := fm.osProxy.DirFS(src)
 	return fs.WalkDir(fsys, ".", func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
@@ -120,7 +132,7 @@ func (fm fileManager) CopyDir(src, dst string) error {
 
 		// "normal" file
 		case 0:
-			return fm.copyFileFS(fsys, path, newPath)
+			return fm.copyFileFS(fsys, path, newPath, opts)
 
 		default:
 			return &os.PathError{Op: "CopyFS", Path: path, Err: os.ErrInvalid}

--- a/fileutil/copy_test.go
+++ b/fileutil/copy_test.go
@@ -5,7 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/bitrise-io/go-utils/v2/fileutil/mocks"
+	"github.com/bitrise-io/go-utils/v2/fileutil/mocks/osproxy"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -17,7 +17,7 @@ func TestCopyFile(t *testing.T) {
 	dstDir := filepath.Join(tmpDir, "dst-dir")
 	assert.NoError(t, os.MkdirAll(dstDir, 0755))
 
-	osProxy := mocks.NewOsProxy(t)
+	osProxy := osproxy.NewOsProxy(t)
 
 	sut := fileManager{osProxy: osProxy}
 
@@ -35,7 +35,36 @@ func TestCopyFile(t *testing.T) {
 	osProxy.EXPECT().Chmod(filepath.Join(dstDir, "file1"), mock.Anything).Return(nil).Once()
 	osProxy.EXPECT().Chtimes(filepath.Join(dstDir, "file1"), mock.Anything, mock.Anything).Return(nil).Once()
 
-	assert.NoError(t, sut.CopyFile(srcDir+"/file1", dstDir+"/file1"))
+	assert.NoError(t, sut.CopyFile(srcDir+"/file1", dstDir+"/file1", nil))
+}
+
+func TestCopyFile_WithOverwrite(t *testing.T) {
+	tmpDir := t.TempDir()
+	srcDir := createSrcDirWithFiles(t, t.TempDir(), []string{"file1"})
+	dstDir := filepath.Join(tmpDir, "dst-dir")
+	assert.NoError(t, os.MkdirAll(dstDir, 0755))
+	// Pre-create the destination file so overwrite is exercised
+	require.NoError(t, os.WriteFile(filepath.Join(dstDir, "file1"), []byte("old"), 0644))
+
+	osProxy := osproxy.NewOsProxy(t)
+
+	sut := fileManager{osProxy: osProxy}
+
+	// Expect srcDir check
+	osProxy.EXPECT().DirFS(srcDir).Return(os.DirFS(srcDir)).Once()
+
+	// Expect dst file open for writing with TRUNC flag (overwrite)
+	osProxy.EXPECT().
+		OpenFile(filepath.Join(dstDir, "file1"), os.O_CREATE|os.O_TRUNC|os.O_WRONLY, mock.Anything).
+		Return(os.OpenFile(filepath.Join(dstDir, "file1"), os.O_CREATE|os.O_TRUNC|os.O_WRONLY, os.FileMode(0o777))).
+		Once()
+
+	// Expect dst file ownership, permissions and times to be set
+	osProxy.EXPECT().Lchown(filepath.Join(dstDir, "file1"), mock.Anything, mock.Anything).Return(nil).Once()
+	osProxy.EXPECT().Chmod(filepath.Join(dstDir, "file1"), mock.Anything).Return(nil).Once()
+	osProxy.EXPECT().Chtimes(filepath.Join(dstDir, "file1"), mock.Anything, mock.Anything).Return(nil).Once()
+
+	assert.NoError(t, sut.CopyFile(srcDir+"/file1", dstDir+"/file1", &CopyOptions{Overwrite: true}))
 }
 
 func TestCopyFile_GivenDstFileOpenFailure_WillFail(t *testing.T) {
@@ -44,7 +73,7 @@ func TestCopyFile_GivenDstFileOpenFailure_WillFail(t *testing.T) {
 	dstDir := filepath.Join(tmpDir, "dst-dir")
 	assert.NoError(t, os.MkdirAll(dstDir, 0755))
 
-	osProxy := mocks.NewOsProxy(t)
+	osProxy := osproxy.NewOsProxy(t)
 
 	sut := fileManager{osProxy: osProxy}
 
@@ -57,7 +86,7 @@ func TestCopyFile_GivenDstFileOpenFailure_WillFail(t *testing.T) {
 		Return(nil, os.ErrPermission).
 		Once()
 
-	assert.ErrorContains(t, sut.CopyFile(srcDir+"/file1", dstDir+"/file1"), os.ErrPermission.Error())
+	assert.ErrorContains(t, sut.CopyFile(srcDir+"/file1", dstDir+"/file1", nil), os.ErrPermission.Error())
 }
 
 func TestCopyFile_GivenDstFileOwnershipChangeFailure_WillFail(t *testing.T) {
@@ -66,7 +95,7 @@ func TestCopyFile_GivenDstFileOwnershipChangeFailure_WillFail(t *testing.T) {
 	dstDir := filepath.Join(tmpDir, "dst-dir")
 	assert.NoError(t, os.MkdirAll(dstDir, 0755))
 
-	osProxy := mocks.NewOsProxy(t)
+	osProxy := osproxy.NewOsProxy(t)
 
 	sut := fileManager{osProxy: osProxy}
 
@@ -82,7 +111,7 @@ func TestCopyFile_GivenDstFileOwnershipChangeFailure_WillFail(t *testing.T) {
 	// Expect dst file ownership, permissions and times to be set
 	osProxy.EXPECT().Lchown(filepath.Join(dstDir, "file1"), mock.Anything, mock.Anything).Return(os.ErrPermission).Once()
 
-	assert.ErrorContains(t, sut.CopyFile(srcDir+"/file1", dstDir+"/file1"), os.ErrPermission.Error())
+	assert.ErrorContains(t, sut.CopyFile(srcDir+"/file1", dstDir+"/file1", nil), os.ErrPermission.Error())
 }
 
 func TestCopyFile_GivenDstFileModeChangeFailure_WillFail(t *testing.T) {
@@ -91,7 +120,7 @@ func TestCopyFile_GivenDstFileModeChangeFailure_WillFail(t *testing.T) {
 	dstDir := filepath.Join(tmpDir, "dst-dir")
 	assert.NoError(t, os.MkdirAll(dstDir, 0755))
 
-	osProxy := mocks.NewOsProxy(t)
+	osProxy := osproxy.NewOsProxy(t)
 
 	sut := fileManager{osProxy: osProxy}
 
@@ -108,7 +137,7 @@ func TestCopyFile_GivenDstFileModeChangeFailure_WillFail(t *testing.T) {
 	osProxy.EXPECT().Lchown(filepath.Join(dstDir, "file1"), mock.Anything, mock.Anything).Return(nil).Once()
 	osProxy.EXPECT().Chmod(filepath.Join(dstDir, "file1"), mock.Anything).Return(os.ErrPermission).Once()
 
-	assert.ErrorContains(t, sut.CopyFile(srcDir+"/file1", dstDir+"/file1"), os.ErrPermission.Error())
+	assert.ErrorContains(t, sut.CopyFile(srcDir+"/file1", dstDir+"/file1", nil), os.ErrPermission.Error())
 }
 
 func TestCopyFile_GivenDstFileTimesChangeFailure_WillFail(t *testing.T) {
@@ -117,7 +146,7 @@ func TestCopyFile_GivenDstFileTimesChangeFailure_WillFail(t *testing.T) {
 	dstDir := filepath.Join(tmpDir, "dst-dir")
 	assert.NoError(t, os.MkdirAll(dstDir, 0755))
 
-	osProxy := mocks.NewOsProxy(t)
+	osProxy := osproxy.NewOsProxy(t)
 
 	sut := fileManager{osProxy: osProxy}
 
@@ -135,7 +164,7 @@ func TestCopyFile_GivenDstFileTimesChangeFailure_WillFail(t *testing.T) {
 	osProxy.EXPECT().Chmod(filepath.Join(dstDir, "file1"), mock.Anything).Return(nil).Once()
 	osProxy.EXPECT().Chtimes(filepath.Join(dstDir, "file1"), mock.Anything, mock.Anything).Return(os.ErrPermission).Once()
 
-	assert.ErrorContains(t, sut.CopyFile(srcDir+"/file1", dstDir+"/file1"), os.ErrPermission.Error())
+	assert.ErrorContains(t, sut.CopyFile(srcDir+"/file1", dstDir+"/file1", nil), os.ErrPermission.Error())
 }
 
 func TestCopyDir(t *testing.T) {
@@ -146,7 +175,7 @@ func TestCopyDir(t *testing.T) {
 	linkTarget := filepath.Join(srcDir, "file1")
 	assert.NoError(t, os.Symlink(linkTarget, filepath.Join(srcDir, "link")))
 
-	osProxy := mocks.NewOsProxy(t)
+	osProxy := osproxy.NewOsProxy(t)
 
 	sut := fileManager{osProxy: osProxy}
 
@@ -171,7 +200,38 @@ func TestCopyDir(t *testing.T) {
 	osProxy.EXPECT().Symlink(linkTarget, filepath.Join(dstDir, "link")).Return(nil).Once()
 	osProxy.EXPECT().Lchown(filepath.Join(dstDir, "link"), mock.Anything, mock.Anything).Return(nil).Once()
 
-	assert.NoError(t, sut.CopyDir(srcDir, dstDir))
+	assert.NoError(t, sut.CopyDir(srcDir, dstDir, nil))
+}
+
+func TestCopyDir_WithOverwrite(t *testing.T) {
+	tmpDir := t.TempDir()
+	srcDir := createSrcDirWithFiles(t, t.TempDir(), []string{"file1"})
+	dstDir := filepath.Join(tmpDir, "dst-dir")
+	assert.NoError(t, os.MkdirAll(dstDir, 0755))
+	// Pre-create the destination file so overwrite is exercised
+	require.NoError(t, os.WriteFile(filepath.Join(dstDir, "file1"), []byte("old"), 0644))
+
+	osProxy := osproxy.NewOsProxy(t)
+
+	sut := fileManager{osProxy: osProxy}
+
+	// Expect changes for dstDir
+	osProxy.EXPECT().MkdirAll(dstDir, mock.Anything).Return(nil).Once()
+	osProxy.EXPECT().Lchown(dstDir, mock.Anything, mock.Anything).Return(nil).Once()
+	osProxy.EXPECT().Chmod(dstDir, mock.Anything).Return(nil).Once()
+	osProxy.EXPECT().Chtimes(dstDir, mock.Anything, mock.Anything).Return(nil).Once()
+
+	// Expect file copy with TRUNC flag (overwrite)
+	osProxy.EXPECT().DirFS(srcDir).Return(os.DirFS(srcDir)).Once()
+	osProxy.EXPECT().
+		OpenFile(filepath.Join(dstDir, "file1"), os.O_CREATE|os.O_TRUNC|os.O_WRONLY, mock.Anything).
+		Return(os.OpenFile(filepath.Join(dstDir, "file1"), os.O_CREATE|os.O_TRUNC|os.O_WRONLY, os.FileMode(0o777))).
+		Once()
+	osProxy.EXPECT().Lchown(filepath.Join(dstDir, "file1"), mock.Anything, mock.Anything).Return(nil).Once()
+	osProxy.EXPECT().Chmod(filepath.Join(dstDir, "file1"), mock.Anything).Return(nil).Once()
+	osProxy.EXPECT().Chtimes(filepath.Join(dstDir, "file1"), mock.Anything, mock.Anything).Return(nil).Once()
+
+	assert.NoError(t, sut.CopyDir(srcDir, dstDir, &CopyOptions{Overwrite: true}))
 }
 
 func TestCopyDir_GivenDstDirCreationFailure_WillFail(t *testing.T) {
@@ -180,7 +240,7 @@ func TestCopyDir_GivenDstDirCreationFailure_WillFail(t *testing.T) {
 	dstDir := filepath.Join(tmpDir, "dst-dir")
 	assert.NoError(t, os.MkdirAll(dstDir, 0755))
 
-	osProxy := mocks.NewOsProxy(t)
+	osProxy := osproxy.NewOsProxy(t)
 
 	sut := fileManager{osProxy: osProxy}
 
@@ -190,7 +250,7 @@ func TestCopyDir_GivenDstDirCreationFailure_WillFail(t *testing.T) {
 	// Expect file copy expectations for file1
 	osProxy.EXPECT().DirFS(srcDir).Return(os.DirFS(srcDir)).Once()
 
-	assert.ErrorContains(t, sut.CopyDir(srcDir, dstDir), os.ErrPermission.Error())
+	assert.ErrorContains(t, sut.CopyDir(srcDir, dstDir, nil), os.ErrPermission.Error())
 }
 
 func TestCopyDir_GivenDstOwnershipChangeFailure_WillFail(t *testing.T) {
@@ -199,7 +259,7 @@ func TestCopyDir_GivenDstOwnershipChangeFailure_WillFail(t *testing.T) {
 	dstDir := filepath.Join(tmpDir, "dst-dir")
 	assert.NoError(t, os.MkdirAll(dstDir, 0755))
 
-	osProxy := mocks.NewOsProxy(t)
+	osProxy := osproxy.NewOsProxy(t)
 
 	sut := fileManager{osProxy: osProxy}
 
@@ -210,7 +270,7 @@ func TestCopyDir_GivenDstOwnershipChangeFailure_WillFail(t *testing.T) {
 	// Expect file copy expectations for file1
 	osProxy.EXPECT().DirFS(srcDir).Return(os.DirFS(srcDir)).Once()
 
-	assert.ErrorContains(t, sut.CopyDir(srcDir, dstDir), os.ErrPermission.Error())
+	assert.ErrorContains(t, sut.CopyDir(srcDir, dstDir, nil), os.ErrPermission.Error())
 }
 
 func TestCopyDir_GivenDstModeChangeFailure_WillFail(t *testing.T) {
@@ -219,7 +279,7 @@ func TestCopyDir_GivenDstModeChangeFailure_WillFail(t *testing.T) {
 	dstDir := filepath.Join(tmpDir, "dst-dir")
 	assert.NoError(t, os.MkdirAll(dstDir, 0755))
 
-	osProxy := mocks.NewOsProxy(t)
+	osProxy := osproxy.NewOsProxy(t)
 
 	sut := fileManager{osProxy: osProxy}
 
@@ -231,7 +291,7 @@ func TestCopyDir_GivenDstModeChangeFailure_WillFail(t *testing.T) {
 	// Expect file copy expectations for file1
 	osProxy.EXPECT().DirFS(srcDir).Return(os.DirFS(srcDir)).Once()
 
-	assert.ErrorContains(t, sut.CopyDir(srcDir, dstDir), os.ErrPermission.Error())
+	assert.ErrorContains(t, sut.CopyDir(srcDir, dstDir, nil), os.ErrPermission.Error())
 }
 
 func TestCopyDir_GivenDstTimesChangeFailure_WillFail(t *testing.T) {
@@ -240,7 +300,7 @@ func TestCopyDir_GivenDstTimesChangeFailure_WillFail(t *testing.T) {
 	dstDir := filepath.Join(tmpDir, "dst-dir")
 	assert.NoError(t, os.MkdirAll(dstDir, 0755))
 
-	osProxy := mocks.NewOsProxy(t)
+	osProxy := osproxy.NewOsProxy(t)
 
 	sut := fileManager{osProxy: osProxy}
 
@@ -253,7 +313,7 @@ func TestCopyDir_GivenDstTimesChangeFailure_WillFail(t *testing.T) {
 	// Expect file copy expectations for file1
 	osProxy.EXPECT().DirFS(srcDir).Return(os.DirFS(srcDir)).Once()
 
-	assert.ErrorContains(t, sut.CopyDir(srcDir, dstDir), os.ErrPermission.Error())
+	assert.ErrorContains(t, sut.CopyDir(srcDir, dstDir, nil), os.ErrPermission.Error())
 }
 
 func TestCopyDir_GivenReadLinkFailure_WillFail(t *testing.T) {
@@ -264,7 +324,7 @@ func TestCopyDir_GivenReadLinkFailure_WillFail(t *testing.T) {
 	linkTarget := filepath.Join(srcDir, "file1")
 	assert.NoError(t, os.Symlink(linkTarget, filepath.Join(srcDir, "link")))
 
-	osProxy := mocks.NewOsProxy(t)
+	osProxy := osproxy.NewOsProxy(t)
 
 	sut := fileManager{osProxy: osProxy}
 
@@ -287,7 +347,7 @@ func TestCopyDir_GivenReadLinkFailure_WillFail(t *testing.T) {
 	// Expect symlink copy expectations for link
 	osProxy.EXPECT().Readlink(filepath.Join(srcDir, "link")).Return("", os.ErrPermission).Once()
 
-	assert.ErrorContains(t, sut.CopyDir(srcDir, dstDir), os.ErrPermission.Error())
+	assert.ErrorContains(t, sut.CopyDir(srcDir, dstDir, nil), os.ErrPermission.Error())
 }
 
 func TestCopyDir_SymlinkFailure_WillFail(t *testing.T) {
@@ -298,7 +358,7 @@ func TestCopyDir_SymlinkFailure_WillFail(t *testing.T) {
 	linkTarget := filepath.Join(srcDir, "file1")
 	assert.NoError(t, os.Symlink(linkTarget, filepath.Join(srcDir, "link")))
 
-	osProxy := mocks.NewOsProxy(t)
+	osProxy := osproxy.NewOsProxy(t)
 
 	sut := fileManager{osProxy: osProxy}
 
@@ -322,7 +382,7 @@ func TestCopyDir_SymlinkFailure_WillFail(t *testing.T) {
 	osProxy.EXPECT().Readlink(filepath.Join(srcDir, "link")).Return(linkTarget, nil).Once()
 	osProxy.EXPECT().Symlink(linkTarget, filepath.Join(dstDir, "link")).Return(os.ErrPermission).Once()
 
-	assert.ErrorContains(t, sut.CopyDir(srcDir, dstDir), os.ErrPermission.Error())
+	assert.ErrorContains(t, sut.CopyDir(srcDir, dstDir, nil), os.ErrPermission.Error())
 }
 
 func TestCopyDir_SymlinkLChownFailure_WillFail(t *testing.T) {
@@ -333,7 +393,7 @@ func TestCopyDir_SymlinkLChownFailure_WillFail(t *testing.T) {
 	linkTarget := filepath.Join(srcDir, "file1")
 	assert.NoError(t, os.Symlink(linkTarget, filepath.Join(srcDir, "link")))
 
-	osProxy := mocks.NewOsProxy(t)
+	osProxy := osproxy.NewOsProxy(t)
 
 	sut := fileManager{osProxy: osProxy}
 
@@ -358,7 +418,7 @@ func TestCopyDir_SymlinkLChownFailure_WillFail(t *testing.T) {
 	osProxy.EXPECT().Symlink(linkTarget, filepath.Join(dstDir, "link")).Return(nil).Once()
 	osProxy.EXPECT().Lchown(filepath.Join(dstDir, "link"), mock.Anything, mock.Anything).Return(os.ErrPermission).Once()
 
-	assert.ErrorContains(t, sut.CopyDir(srcDir, dstDir), os.ErrPermission.Error())
+	assert.ErrorContains(t, sut.CopyDir(srcDir, dstDir, nil), os.ErrPermission.Error())
 }
 
 // ---------------------------

--- a/fileutil/fileutil.go
+++ b/fileutil/fileutil.go
@@ -9,6 +9,12 @@ import (
 	"strings"
 )
 
+// CopyOptions configures a [FileManager.CopyFile] operation.
+// A nil pointer means default behavior.
+type CopyOptions struct {
+	Overwrite bool // Overwrite replaces the destination file if it already exists.
+}
+
 // FileManager ...
 type FileManager interface {
 	Open(path string) (*os.File, error)
@@ -19,8 +25,8 @@ type FileManager interface {
 	Write(path string, value string, perm os.FileMode) error
 	WriteBytes(path string, value []byte) error
 	FileSizeInBytes(pth string) (int64, error)
-	CopyFile(src, dst string) error
-	CopyDir(src, dst string) error
+	CopyFile(src, dst string, opts *CopyOptions) error
+	CopyDir(src, dst string, opts *CopyOptions) error
 	Lstat(path string) (os.FileInfo, error)
 	LastNLines(s string, n int) string
 }

--- a/fileutil/mocks/FileManager.go
+++ b/fileutil/mocks/FileManager.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 
+	fileutil "github.com/bitrise-io/go-utils/v2/fileutil"
 	mock "github.com/stretchr/testify/mock"
 )
 
@@ -39,16 +40,16 @@ func (_m *FileManager) EXPECT() *FileManager_Expecter {
 }
 
 // CopyDir provides a mock function for the type FileManager
-func (_mock *FileManager) CopyDir(src string, dst string) error {
-	ret := _mock.Called(src, dst)
+func (_mock *FileManager) CopyDir(src string, dst string, opts *fileutil.CopyOptions) error {
+	ret := _mock.Called(src, dst, opts)
 
 	if len(ret) == 0 {
 		panic("no return value specified for CopyDir")
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(string, string) error); ok {
-		r0 = returnFunc(src, dst)
+	if returnFunc, ok := ret.Get(0).(func(string, string, *fileutil.CopyOptions) error); ok {
+		r0 = returnFunc(src, dst, opts)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -63,11 +64,12 @@ type FileManager_CopyDir_Call struct {
 // CopyDir is a helper method to define mock.On call
 //   - src string
 //   - dst string
-func (_e *FileManager_Expecter) CopyDir(src interface{}, dst interface{}) *FileManager_CopyDir_Call {
-	return &FileManager_CopyDir_Call{Call: _e.mock.On("CopyDir", src, dst)}
+//   - opts *fileutil.CopyOptions
+func (_e *FileManager_Expecter) CopyDir(src interface{}, dst interface{}, opts interface{}) *FileManager_CopyDir_Call {
+	return &FileManager_CopyDir_Call{Call: _e.mock.On("CopyDir", src, dst, opts)}
 }
 
-func (_c *FileManager_CopyDir_Call) Run(run func(src string, dst string)) *FileManager_CopyDir_Call {
+func (_c *FileManager_CopyDir_Call) Run(run func(src string, dst string, opts *fileutil.CopyOptions)) *FileManager_CopyDir_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 string
 		if args[0] != nil {
@@ -77,9 +79,14 @@ func (_c *FileManager_CopyDir_Call) Run(run func(src string, dst string)) *FileM
 		if args[1] != nil {
 			arg1 = args[1].(string)
 		}
+		var arg2 *fileutil.CopyOptions
+		if args[2] != nil {
+			arg2 = args[2].(*fileutil.CopyOptions)
+		}
 		run(
 			arg0,
 			arg1,
+			arg2,
 		)
 	})
 	return _c
@@ -90,22 +97,22 @@ func (_c *FileManager_CopyDir_Call) Return(err error) *FileManager_CopyDir_Call 
 	return _c
 }
 
-func (_c *FileManager_CopyDir_Call) RunAndReturn(run func(src string, dst string) error) *FileManager_CopyDir_Call {
+func (_c *FileManager_CopyDir_Call) RunAndReturn(run func(src string, dst string, opts *fileutil.CopyOptions) error) *FileManager_CopyDir_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // CopyFile provides a mock function for the type FileManager
-func (_mock *FileManager) CopyFile(src string, dst string) error {
-	ret := _mock.Called(src, dst)
+func (_mock *FileManager) CopyFile(src string, dst string, opts *fileutil.CopyOptions) error {
+	ret := _mock.Called(src, dst, opts)
 
 	if len(ret) == 0 {
 		panic("no return value specified for CopyFile")
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(string, string) error); ok {
-		r0 = returnFunc(src, dst)
+	if returnFunc, ok := ret.Get(0).(func(string, string, *fileutil.CopyOptions) error); ok {
+		r0 = returnFunc(src, dst, opts)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -120,11 +127,12 @@ type FileManager_CopyFile_Call struct {
 // CopyFile is a helper method to define mock.On call
 //   - src string
 //   - dst string
-func (_e *FileManager_Expecter) CopyFile(src interface{}, dst interface{}) *FileManager_CopyFile_Call {
-	return &FileManager_CopyFile_Call{Call: _e.mock.On("CopyFile", src, dst)}
+//   - opts *fileutil.CopyOptions
+func (_e *FileManager_Expecter) CopyFile(src interface{}, dst interface{}, opts interface{}) *FileManager_CopyFile_Call {
+	return &FileManager_CopyFile_Call{Call: _e.mock.On("CopyFile", src, dst, opts)}
 }
 
-func (_c *FileManager_CopyFile_Call) Run(run func(src string, dst string)) *FileManager_CopyFile_Call {
+func (_c *FileManager_CopyFile_Call) Run(run func(src string, dst string, opts *fileutil.CopyOptions)) *FileManager_CopyFile_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 string
 		if args[0] != nil {
@@ -134,9 +142,14 @@ func (_c *FileManager_CopyFile_Call) Run(run func(src string, dst string)) *File
 		if args[1] != nil {
 			arg1 = args[1].(string)
 		}
+		var arg2 *fileutil.CopyOptions
+		if args[2] != nil {
+			arg2 = args[2].(*fileutil.CopyOptions)
+		}
 		run(
 			arg0,
 			arg1,
+			arg2,
 		)
 	})
 	return _c
@@ -147,7 +160,7 @@ func (_c *FileManager_CopyFile_Call) Return(err error) *FileManager_CopyFile_Cal
 	return _c
 }
 
-func (_c *FileManager_CopyFile_Call) RunAndReturn(run func(src string, dst string) error) *FileManager_CopyFile_Call {
+func (_c *FileManager_CopyFile_Call) RunAndReturn(run func(src string, dst string, opts *fileutil.CopyOptions) error) *FileManager_CopyFile_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/fileutil/mocks/osproxy/OsProxy.go
+++ b/fileutil/mocks/osproxy/OsProxy.go
@@ -2,7 +2,7 @@
 // github.com/vektra/mockery
 // template: testify
 
-package mocks
+package osproxy
 
 import (
 	"io/fs"


### PR DESCRIPTION
## Summary

- Add `CopyOptions` struct with `Overwrite bool` field to `fileutil` package
- Update `CopyFile` and `CopyDir` interface signatures to accept `*CopyOptions`
- When `opts.Overwrite == true`, uses `O_TRUNC` instead of `O_EXCL` (default still fails if destination exists)
- Move `OsProxy` mock to `mocks/osproxy/` sub-package to avoid import cycle (the `FileManager` mock now imports `fileutil` for `CopyOptions`)
- Add `TestCopyFile_WithOverwrite` and `TestCopyDir_WithOverwrite` tests

## Note

This is a **breaking change** to the `FileManager` interface — callers must add a `nil` (or `&CopyOptions{}`) argument to existing `CopyFile`/`CopyDir` calls.

This PR is a prerequisite for the corresponding go-steputils branch `STEP-2177-move-filemanager-to-utils`.

## Test plan

- [x] Existing tests updated to pass `nil` for opts
- [x] New overwrite tests verify `O_TRUNC` flag is used
- [x] `go test ./fileutil/...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)