### PR TITLE
[STEP-2135] Migrate pathutil filters and sortable path to v2

### DIFF
--- a/pathutil/path_filter.go
+++ b/pathutil/path_filter.go
@@ -1,0 +1,155 @@
+package pathutil
+
+import (
+	"errors"
+	"io/fs"
+	"path"
+	"regexp"
+	"slices"
+	"strings"
+)
+
+// FilterFunc decides whether an entry produced by an fs.FS walk should be
+// kept. The path is slash-separated and rooted at the fs root ("." for the
+// root itself). Returning fs.SkipDir as the error skips the current
+// directory's subtree.
+type FilterFunc func(pth string, d fs.DirEntry) (bool, error)
+
+// FilterFS walks fsys recursively and returns every path for which all
+// filters return true. Paths are slash-separated and relative to fsys.
+func FilterFS(fsys fs.FS, filters ...FilterFunc) ([]string, error) {
+	var filtered []string
+
+	err := fs.WalkDir(fsys, ".", func(pth string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+
+		for _, filter := range filters {
+			matches, err := filter(pth, d)
+			if err != nil {
+				return err
+			}
+			if !matches {
+				return nil
+			}
+		}
+
+		filtered = append(filtered, pth)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return filtered, nil
+}
+
+// BaseFilter matches entries whose base name equals base (case-insensitive).
+// When allowed is false the match is inverted.
+func BaseFilter(base string, allowed bool) FilterFunc {
+	return func(pth string, _ fs.DirEntry) (bool, error) {
+		return allowed == strings.EqualFold(path.Base(pth), base), nil
+	}
+}
+
+// ExtensionFilter matches entries whose extension equals ext
+// (case-insensitive, leading dot included, e.g. ".txt").
+func ExtensionFilter(ext string, allowed bool) FilterFunc {
+	return func(pth string, _ fs.DirEntry) (bool, error) {
+		return allowed == strings.EqualFold(path.Ext(pth), ext), nil
+	}
+}
+
+// RegexpFilter matches entries whose path contains a match for pattern.
+// The pattern is compiled once when the filter is constructed.
+func RegexpFilter(pattern string, allowed bool) FilterFunc {
+	re := regexp.MustCompile(pattern)
+	return func(pth string, _ fs.DirEntry) (bool, error) {
+		return allowed == (re.FindString(pth) != ""), nil
+	}
+}
+
+// ComponentFilter matches entries whose path contains component as one of
+// its slash-separated components.
+func ComponentFilter(component string, allowed bool) FilterFunc {
+	return func(pth string, _ fs.DirEntry) (bool, error) {
+		found := slices.Contains(strings.Split(pth, "/"), component)
+		return allowed == found, nil
+	}
+}
+
+// ComponentWithExtensionFilter matches entries whose path has at least one
+// component with the given extension.
+func ComponentWithExtensionFilter(ext string, allowed bool) FilterFunc {
+	return func(pth string, _ fs.DirEntry) (bool, error) {
+		found := slices.ContainsFunc(strings.Split(pth, "/"), func(c string) bool {
+			return path.Ext(c) == ext
+		})
+		return allowed == found, nil
+	}
+}
+
+// IsDirectoryFilter matches entries based on whether they are directories.
+func IsDirectoryFilter(allowed bool) FilterFunc {
+	return func(_ string, d fs.DirEntry) (bool, error) {
+		if d == nil {
+			return false, errors.New("no directory entry available")
+		}
+		return allowed == d.IsDir(), nil
+	}
+}
+
+// InDirectoryFilter matches entries whose direct parent directory equals dir.
+func InDirectoryFilter(dir string, allowed bool) FilterFunc {
+	return func(pth string, _ fs.DirEntry) (bool, error) {
+		return allowed == (path.Dir(pth) == dir), nil
+	}
+}
+
+// SkipDirectoryNameFilter keeps every non-directory entry. When it encounters
+// a directory whose base name matches dirName (case-insensitive) it returns
+// fs.SkipDir so the whole subtree is skipped.
+func SkipDirectoryNameFilter(dirName string) FilterFunc {
+	return func(pth string, d fs.DirEntry) (bool, error) {
+		if d == nil || !d.IsDir() {
+			return true, nil
+		}
+		if strings.EqualFold(path.Base(pth), dirName) {
+			return false, fs.SkipDir
+		}
+		return true, nil
+	}
+}
+
+// DirectoryContainsFileFilter matches directories that contain a regular
+// file named fileName. fsys is used to stat the candidate path.
+func DirectoryContainsFileFilter(fsys fs.FS, fileName string) FilterFunc {
+	return func(pth string, d fs.DirEntry) (bool, error) {
+		if d == nil || !d.IsDir() {
+			return false, nil
+		}
+		info, err := fs.Stat(fsys, path.Join(pth, fileName))
+		if err != nil {
+			if errors.Is(err, fs.ErrNotExist) {
+				return false, nil
+			}
+			return false, err
+		}
+		return !info.IsDir(), nil
+	}
+}
+
+// FileContainsFilter matches regular files whose contents include content.
+// Directories never match.
+func FileContainsFilter(fsys fs.FS, content string) FilterFunc {
+	return func(pth string, d fs.DirEntry) (bool, error) {
+		if d != nil && d.IsDir() {
+			return false, nil
+		}
+		data, err := fs.ReadFile(fsys, pth)
+		if err != nil {
+			return false, err
+		}
+		return strings.Contains(string(data), content), nil
+	}
+}

--- a/pathutil/path_filter.go
+++ b/pathutil/path_filter.go
@@ -79,11 +79,12 @@ func ComponentFilter(component string, allowed bool) FilterFunc {
 }
 
 // ComponentWithExtensionFilter matches entries whose path has at least one
-// component with the given extension.
+// component with the given extension (case-insensitive, leading dot
+// included, e.g. ".xcodeproj").
 func ComponentWithExtensionFilter(ext string, allowed bool) FilterFunc {
 	return func(pth string, _ fs.DirEntry) (bool, error) {
 		found := slices.ContainsFunc(strings.Split(pth, "/"), func(c string) bool {
-			return path.Ext(c) == ext
+			return strings.EqualFold(path.Ext(c), ext)
 		})
 		return allowed == found, nil
 	}

--- a/pathutil/path_filter_compat.go
+++ b/pathutil/path_filter_compat.go
@@ -1,0 +1,84 @@
+package pathutil
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+)
+
+// FilterPaths applies filters to an explicit list of OS paths and returns
+// the ones that pass every filter, preserving input order. Each path is
+// stat-ed to build an fs.DirEntry for the filter callbacks; a missing path
+// surfaces the stat error.
+//
+// This adapter preserves the v1 go-utils pathutil.FilterPaths signature so
+// callers can migrate by import-path rename only. Prefer FilterFS in new code.
+func FilterPaths(paths []string, filters ...FilterFunc) ([]string, error) {
+	var filtered []string
+	for _, pth := range paths {
+		info, err := os.Lstat(pth)
+		if err != nil {
+			return nil, err
+		}
+		d := fs.FileInfoToDirEntry(info)
+
+		keep, err := runFilters(pth, d, filters)
+		if err != nil {
+			return nil, err
+		}
+		if keep {
+			filtered = append(filtered, pth)
+		}
+	}
+	return filtered, nil
+}
+
+// ListEntries lists the immediate children of dir, applies filters, and
+// returns the matching entries as absolute paths. It is non-recursive.
+//
+// This adapter preserves the v1 go-utils pathutil.ListEntries signature so
+// callers can migrate by import-path rename only. Prefer FilterFS on an
+// fs.FS in new code.
+func ListEntries(dir string, filters ...FilterFunc) ([]string, error) {
+	absDir, err := filepath.Abs(dir)
+	if err != nil {
+		return nil, err
+	}
+	entries, err := os.ReadDir(absDir)
+	if err != nil {
+		return nil, err
+	}
+
+	var filtered []string
+	for _, entry := range entries {
+		pth := filepath.Join(absDir, entry.Name())
+		keep, err := runFilters(pth, entry, filters)
+		if err != nil {
+			return nil, err
+		}
+		if keep {
+			filtered = append(filtered, pth)
+		}
+	}
+	return filtered, nil
+}
+
+// runFilters evaluates filters in order. fs.SkipDir from a filter is
+// treated as "exclude this entry" rather than a walk directive, because the
+// compat adapters do not walk a tree.
+func runFilters(pth string, d fs.DirEntry, filters []FilterFunc) (bool, error) {
+	for _, filter := range filters {
+		matches, err := filter(pth, d)
+		if err != nil {
+			if errors.Is(err, fs.SkipDir) {
+				return false, nil
+			}
+			return false, err
+		}
+		if !matches {
+			return false, nil
+		}
+	}
+	return true, nil
+}

--- a/pathutil/path_filter_compat.go
+++ b/pathutil/path_filter_compat.go
@@ -31,7 +31,7 @@ func FilterPaths(paths []string, filters ...FilterFunc) ([]string, error) {
 			return nil, err
 		}
 
-		keep, err := runFilters(pth, d, filters)
+		keep, err := runFilters(filepath.ToSlash(pth), d, filters)
 		if err != nil {
 			return nil, err
 		}
@@ -61,7 +61,7 @@ func ListEntries(dir string, filters ...FilterFunc) ([]string, error) {
 	var filtered []string
 	for _, entry := range entries {
 		pth := filepath.Join(absDir, entry.Name())
-		keep, err := runFilters(pth, entry, filters)
+		keep, err := runFilters(filepath.ToSlash(pth), entry, filters)
 		if err != nil {
 			return nil, err
 		}

--- a/pathutil/path_filter_compat.go
+++ b/pathutil/path_filter_compat.go
@@ -9,19 +9,27 @@ import (
 
 // FilterPaths applies filters to an explicit list of OS paths and returns
 // the ones that pass every filter, preserving input order. Each path is
-// stat-ed to build an fs.DirEntry for the filter callbacks; a missing path
-// surfaces the stat error.
+// stat-ed opportunistically so filters that consult fs.DirEntry (e.g.
+// IsDirectoryFilter) work; paths that do not exist on disk are still fed
+// to the filters with a nil DirEntry, matching v1's purely lexical
+// behavior for path-only filters. Stat errors other than "not exist"
+// surface to the caller.
 //
 // This adapter preserves the v1 go-utils pathutil.FilterPaths signature so
 // callers can migrate by import-path rename only. Prefer FilterFS in new code.
 func FilterPaths(paths []string, filters ...FilterFunc) ([]string, error) {
 	var filtered []string
 	for _, pth := range paths {
+		var d fs.DirEntry
 		info, err := os.Lstat(pth)
-		if err != nil {
+		switch {
+		case err == nil:
+			d = fs.FileInfoToDirEntry(info)
+		case errors.Is(err, fs.ErrNotExist):
+			// Leave d nil; path-only filters still work.
+		default:
 			return nil, err
 		}
-		d := fs.FileInfoToDirEntry(info)
 
 		keep, err := runFilters(pth, d, filters)
 		if err != nil {

--- a/pathutil/path_filter_compat_test.go
+++ b/pathutil/path_filter_compat_test.go
@@ -1,0 +1,81 @@
+package pathutil
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func writeTempTree(t *testing.T) string {
+	t.Helper()
+
+	root := t.TempDir()
+
+	files := map[string]string{
+		"README.md":            "# readme",
+		"main.go":              "package main",
+		"main_test.go":         "package main",
+		"sub/note.txt":         "todo",
+		"sub/nested/deep.txt":  "x",
+		"vendor/pkg/lib.go":    "package pkg",
+	}
+	for rel, content := range files {
+		full := filepath.Join(root, rel)
+		require.NoError(t, os.MkdirAll(filepath.Dir(full), 0o755))
+		require.NoError(t, os.WriteFile(full, []byte(content), 0o644))
+	}
+	return root
+}
+
+func TestFilterPaths(t *testing.T) {
+	root := writeTempTree(t)
+	paths := []string{
+		filepath.Join(root, "README.md"),
+		filepath.Join(root, "main.go"),
+		filepath.Join(root, "main_test.go"),
+		filepath.Join(root, "sub"),
+	}
+
+	got, err := FilterPaths(paths, ExtensionFilter(".go", true), IsDirectoryFilter(false))
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{
+		filepath.Join(root, "main.go"),
+		filepath.Join(root, "main_test.go"),
+	}, got)
+}
+
+func TestFilterPaths_missingPathErrors(t *testing.T) {
+	_, err := FilterPaths([]string{"/does/not/exist/ever"}, IsDirectoryFilter(false))
+	require.Error(t, err)
+}
+
+func TestFilterPaths_empty(t *testing.T) {
+	got, err := FilterPaths(nil, ExtensionFilter(".go", true))
+	require.NoError(t, err)
+	require.Empty(t, got)
+}
+
+func TestListEntries(t *testing.T) {
+	root := writeTempTree(t)
+
+	got, err := ListEntries(root, IsDirectoryFilter(false))
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{
+		filepath.Join(root, "README.md"),
+		filepath.Join(root, "main.go"),
+		filepath.Join(root, "main_test.go"),
+	}, got, "ListEntries must be non-recursive")
+}
+
+func TestListEntries_onlyDirs(t *testing.T) {
+	root := writeTempTree(t)
+
+	got, err := ListEntries(root, IsDirectoryFilter(true))
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{
+		filepath.Join(root, "sub"),
+		filepath.Join(root, "vendor"),
+	}, got)
+}

--- a/pathutil/path_filter_compat_test.go
+++ b/pathutil/path_filter_compat_test.go
@@ -46,7 +46,20 @@ func TestFilterPaths(t *testing.T) {
 	}, got)
 }
 
-func TestFilterPaths_missingPathErrors(t *testing.T) {
+func TestFilterPaths_missingPath_pathOnlyFilters(t *testing.T) {
+	// v1 parity: purely lexical filters work against paths that do not
+	// exist on disk. IsDirectoryFilter is not used here so no stat is needed.
+	got, err := FilterPaths(
+		[]string{"./Podfile", "/nowhere/Podfile.lock"},
+		BaseFilter("Podfile", true),
+	)
+	require.NoError(t, err)
+	require.Equal(t, []string{"./Podfile"}, got)
+}
+
+func TestFilterPaths_missingPath_dirEntryFilterErrors(t *testing.T) {
+	// Filters that consult the DirEntry (IsDirectoryFilter) still error on
+	// missing paths because there is nothing to inspect.
 	_, err := FilterPaths([]string{"/does/not/exist/ever"}, IsDirectoryFilter(false))
 	require.Error(t, err)
 }

--- a/pathutil/path_filter_test.go
+++ b/pathutil/path_filter_test.go
@@ -1,0 +1,164 @@
+package pathutil
+
+import (
+	"errors"
+	"io/fs"
+	"testing"
+	"testing/fstest"
+
+	"github.com/stretchr/testify/require"
+)
+
+func buildTestFS() fstest.MapFS {
+	return fstest.MapFS{
+		"src/main.go":             {Data: []byte("package main\nfunc main(){}\n")},
+		"src/util/helper.go":      {Data: []byte("package util\n// TODO: refactor\n")},
+		"src/util/helper_test.go": {Data: []byte("package util\n")},
+		"docs/readme.md":          {Data: []byte("# readme\n")},
+		"vendor/pkg/lib.go":       {Data: []byte("package pkg\n")},
+		"Info.plist":              {Data: []byte("plist")},
+	}
+}
+
+func TestBaseFilter(t *testing.T) {
+	fsys := buildTestFS()
+
+	got, err := FilterFS(fsys, BaseFilter("main.go", true), IsDirectoryFilter(false))
+	require.NoError(t, err)
+	require.Equal(t, []string{"src/main.go"}, got)
+
+	got, err = FilterFS(fsys, BaseFilter("MAIN.GO", true), IsDirectoryFilter(false))
+	require.NoError(t, err, "case-insensitive match expected")
+	require.Equal(t, []string{"src/main.go"}, got)
+
+	got, err = FilterFS(fsys, BaseFilter("main.go", false), IsDirectoryFilter(false))
+	require.NoError(t, err)
+	require.NotContains(t, got, "src/main.go")
+}
+
+func TestExtensionFilter(t *testing.T) {
+	fsys := buildTestFS()
+
+	got, err := FilterFS(fsys, ExtensionFilter(".md", true), IsDirectoryFilter(false))
+	require.NoError(t, err)
+	require.Equal(t, []string{"docs/readme.md"}, got)
+
+	got, err = FilterFS(fsys, ExtensionFilter(".MD", true), IsDirectoryFilter(false))
+	require.NoError(t, err)
+	require.Equal(t, []string{"docs/readme.md"}, got)
+}
+
+func TestRegexpFilter(t *testing.T) {
+	fsys := buildTestFS()
+
+	got, err := FilterFS(fsys, RegexpFilter(`.*_test\.go$`, true), IsDirectoryFilter(false))
+	require.NoError(t, err)
+	require.Equal(t, []string{"src/util/helper_test.go"}, got)
+
+	got, err = FilterFS(fsys, RegexpFilter(`.*_test\.go$`, false), IsDirectoryFilter(false))
+	require.NoError(t, err)
+	require.NotContains(t, got, "src/util/helper_test.go")
+}
+
+func TestComponentFilter(t *testing.T) {
+	fsys := buildTestFS()
+
+	got, err := FilterFS(fsys, ComponentFilter("vendor", true))
+	require.NoError(t, err)
+	require.Equal(t, []string{"vendor", "vendor/pkg", "vendor/pkg/lib.go"}, got)
+
+	got, err = FilterFS(fsys, ComponentFilter("vendor", false), IsDirectoryFilter(false))
+	require.NoError(t, err)
+	require.NotContains(t, got, "vendor/pkg/lib.go")
+}
+
+func TestComponentWithExtensionFilter(t *testing.T) {
+	fsys := fstest.MapFS{
+		"proj.xcodeproj/project.pbxproj": {Data: []byte("x")},
+		"src/main.go":                    {Data: []byte("x")},
+	}
+
+	got, err := FilterFS(fsys, ComponentWithExtensionFilter(".xcodeproj", true), IsDirectoryFilter(false))
+	require.NoError(t, err)
+	require.Equal(t, []string{"proj.xcodeproj/project.pbxproj"}, got)
+}
+
+func TestIsDirectoryFilter(t *testing.T) {
+	fsys := fstest.MapFS{
+		"a/b.txt": {Data: []byte("x")},
+	}
+
+	dirs, err := FilterFS(fsys, IsDirectoryFilter(true))
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{".", "a"}, dirs)
+
+	files, err := FilterFS(fsys, IsDirectoryFilter(false))
+	require.NoError(t, err)
+	require.Equal(t, []string{"a/b.txt"}, files)
+}
+
+func TestInDirectoryFilter(t *testing.T) {
+	fsys := buildTestFS()
+
+	got, err := FilterFS(fsys, InDirectoryFilter("src", true), IsDirectoryFilter(false))
+	require.NoError(t, err)
+	require.Equal(t, []string{"src/main.go"}, got)
+
+	got, err = FilterFS(fsys, InDirectoryFilter("src/util", true), IsDirectoryFilter(false))
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{"src/util/helper.go", "src/util/helper_test.go"}, got)
+}
+
+func TestSkipDirectoryNameFilter(t *testing.T) {
+	fsys := buildTestFS()
+
+	got, err := FilterFS(fsys, SkipDirectoryNameFilter("vendor"), IsDirectoryFilter(false))
+	require.NoError(t, err)
+	require.NotContains(t, got, "vendor/pkg/lib.go", "vendor subtree must be skipped")
+	require.Contains(t, got, "src/main.go")
+}
+
+func TestDirectoryContainsFileFilter(t *testing.T) {
+	fsys := fstest.MapFS{
+		"proj-a/Podfile":        {Data: []byte("pod 'X'")},
+		"proj-a/main.m":         {Data: []byte("x")},
+		"proj-b/main.m":         {Data: []byte("x")},
+		"proj-c/Podfile/nested": {Data: []byte("x")}, // "Podfile" is a dir here
+	}
+
+	got, err := FilterFS(fsys, DirectoryContainsFileFilter(fsys, "Podfile"), IsDirectoryFilter(true))
+	require.NoError(t, err)
+	require.Equal(t, []string{"proj-a"}, got)
+}
+
+func TestFileContainsFilter(t *testing.T) {
+	fsys := buildTestFS()
+
+	got, err := FilterFS(fsys, FileContainsFilter(fsys, "TODO"), IsDirectoryFilter(false))
+	require.NoError(t, err)
+	require.Equal(t, []string{"src/util/helper.go"}, got)
+}
+
+func TestFilterFS_propagatesError(t *testing.T) {
+	sentinel := errors.New("boom")
+	bad := func(string, fs.DirEntry) (bool, error) {
+		return false, sentinel
+	}
+
+	_, err := FilterFS(fstest.MapFS{"a": {Data: []byte("x")}}, bad)
+	require.ErrorIs(t, err, sentinel)
+}
+
+func TestFilterFS_composite(t *testing.T) {
+	fsys := buildTestFS()
+
+	got, err := FilterFS(
+		fsys,
+		SkipDirectoryNameFilter("vendor"),
+		IsDirectoryFilter(false),
+		ExtensionFilter(".go", true),
+		RegexpFilter(`.*_test\.go$`, false),
+	)
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{"src/main.go", "src/util/helper.go"}, got)
+}

--- a/pathutil/sortable_path.go
+++ b/pathutil/sortable_path.go
@@ -1,0 +1,102 @@
+package pathutil
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// SortablePath pairs a path with its absolute form and component breakdown,
+// enabling sorts that compare entries by directory depth.
+type SortablePath struct {
+	Pth        string
+	AbsPth     string
+	Components []string
+}
+
+// NewSortablePath expands pth to its absolute form and splits it into
+// non-empty components suitable for depth-based sorting.
+func NewSortablePath(pth string) (SortablePath, error) {
+	absPth, err := pathModifier{}.AbsPath(pth)
+	if err != nil {
+		return SortablePath{}, err
+	}
+
+	var components []string
+	for _, c := range strings.Split(absPth, string(os.PathSeparator)) {
+		if c != "" {
+			components = append(components, c)
+		}
+	}
+
+	return SortablePath{
+		Pth:        pth,
+		AbsPth:     absPth,
+		Components: components,
+	}, nil
+}
+
+// BySortablePathComponents sorts SortablePath values by component depth
+// (shallowest first), breaking ties alphabetically on the base name.
+type BySortablePathComponents []SortablePath
+
+func (s BySortablePathComponents) Len() int      { return len(s) }
+func (s BySortablePathComponents) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
+func (s BySortablePathComponents) Less(i, j int) bool {
+	if len(s[i].Components) != len(s[j].Components) {
+		return len(s[i].Components) < len(s[j].Components)
+	}
+	return filepath.Base(s[i].AbsPth) < filepath.Base(s[j].AbsPth)
+}
+
+// SortPathsByComponents returns paths sorted by directory depth.
+func SortPathsByComponents(paths []string) ([]string, error) {
+	sortables := make([]SortablePath, 0, len(paths))
+	for _, p := range paths {
+		sp, err := NewSortablePath(p)
+		if err != nil {
+			return nil, err
+		}
+		sortables = append(sortables, sp)
+	}
+
+	sort.Sort(BySortablePathComponents(sortables))
+
+	sorted := make([]string, 0, len(sortables))
+	for _, sp := range sortables {
+		sorted = append(sorted, sp.Pth)
+	}
+	return sorted, nil
+}
+
+// ListPathInDirSortedByComponents walks searchDir recursively and returns
+// every path found, sorted by directory depth. If relPath is true the paths
+// are returned relative to searchDir.
+func ListPathInDirSortedByComponents(searchDir string, relPath bool) ([]string, error) {
+	absDir, err := filepath.Abs(searchDir)
+	if err != nil {
+		return nil, err
+	}
+
+	var paths []string
+	err = filepath.WalkDir(absDir, func(p string, _ fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if relPath {
+			rel, err := filepath.Rel(absDir, p)
+			if err != nil {
+				return err
+			}
+			p = rel
+		}
+		paths = append(paths, p)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return SortPathsByComponents(paths)
+}

--- a/pathutil/sortable_path.go
+++ b/pathutil/sortable_path.go
@@ -39,7 +39,9 @@ func NewSortablePath(pth string) (SortablePath, error) {
 }
 
 // BySortablePathComponents sorts SortablePath values by component depth
-// (shallowest first), breaking ties alphabetically on the base name.
+// (shallowest first), breaking ties alphabetically on the base name and
+// falling back to the absolute and original paths to keep the order
+// deterministic when same-depth same-base entries exist.
 type BySortablePathComponents []SortablePath
 
 func (s BySortablePathComponents) Len() int      { return len(s) }
@@ -48,7 +50,14 @@ func (s BySortablePathComponents) Less(i, j int) bool {
 	if len(s[i].Components) != len(s[j].Components) {
 		return len(s[i].Components) < len(s[j].Components)
 	}
-	return filepath.Base(s[i].AbsPth) < filepath.Base(s[j].AbsPth)
+	baseI, baseJ := filepath.Base(s[i].AbsPth), filepath.Base(s[j].AbsPth)
+	if baseI != baseJ {
+		return baseI < baseJ
+	}
+	if s[i].AbsPth != s[j].AbsPth {
+		return s[i].AbsPth < s[j].AbsPth
+	}
+	return s[i].Pth < s[j].Pth
 }
 
 // SortPathsByComponents returns paths sorted by directory depth.

--- a/pathutil/sortable_path_test.go
+++ b/pathutil/sortable_path_test.go
@@ -3,12 +3,26 @@ package pathutil
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
 
+// These tests assume POSIX-style absolute paths (no drive letter, "/" as
+// separator). filepath.Abs and component splitting differ on Windows, so
+// the bare-string assertions would not hold there. CI for go-utils runs on
+// Linux and macOS only; skip on Windows to keep the test honest.
+func skipOnWindows(t *testing.T) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX-only: filepath.Abs and component split differ on Windows")
+	}
+}
+
 func TestNewSortablePath(t *testing.T) {
+	skipOnWindows(t)
+
 	sp, err := NewSortablePath("/a/b/c.txt")
 	require.NoError(t, err)
 	require.Equal(t, "/a/b/c.txt", sp.Pth)
@@ -17,6 +31,8 @@ func TestNewSortablePath(t *testing.T) {
 }
 
 func TestSortPathsByComponents(t *testing.T) {
+	skipOnWindows(t)
+
 	input := []string{
 		"/a/b/c/deep.txt",
 		"/x.txt",
@@ -35,11 +51,25 @@ func TestSortPathsByComponents(t *testing.T) {
 }
 
 func TestSortPathsByComponents_tiebreakAlphabetic(t *testing.T) {
+	skipOnWindows(t)
+
 	input := []string{"/a/zeta.txt", "/a/alpha.txt", "/a/mu.txt"}
 
 	got, err := SortPathsByComponents(input)
 	require.NoError(t, err)
 	require.Equal(t, []string{"/a/alpha.txt", "/a/mu.txt", "/a/zeta.txt"}, got)
+}
+
+func TestSortPathsByComponents_tiebreakSameBaseDifferentDir(t *testing.T) {
+	skipOnWindows(t)
+
+	// Same depth, same base name — without the AbsPth tie-breaker the
+	// resulting order would be nondeterministic (sort.Sort is not stable).
+	input := []string{"/b/x.txt", "/a/x.txt"}
+
+	got, err := SortPathsByComponents(input)
+	require.NoError(t, err)
+	require.Equal(t, []string{"/a/x.txt", "/b/x.txt"}, got)
 }
 
 func TestListPathInDirSortedByComponents(t *testing.T) {

--- a/pathutil/sortable_path_test.go
+++ b/pathutil/sortable_path_test.go
@@ -1,0 +1,66 @@
+package pathutil
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewSortablePath(t *testing.T) {
+	sp, err := NewSortablePath("/a/b/c.txt")
+	require.NoError(t, err)
+	require.Equal(t, "/a/b/c.txt", sp.Pth)
+	require.Equal(t, "/a/b/c.txt", sp.AbsPth)
+	require.Equal(t, []string{"a", "b", "c.txt"}, sp.Components)
+}
+
+func TestSortPathsByComponents(t *testing.T) {
+	input := []string{
+		"/a/b/c/deep.txt",
+		"/x.txt",
+		"/a/mid.txt",
+		"/a/b/other.txt",
+	}
+
+	got, err := SortPathsByComponents(input)
+	require.NoError(t, err)
+	require.Equal(t, []string{
+		"/x.txt",
+		"/a/mid.txt",
+		"/a/b/other.txt",
+		"/a/b/c/deep.txt",
+	}, got)
+}
+
+func TestSortPathsByComponents_tiebreakAlphabetic(t *testing.T) {
+	input := []string{"/a/zeta.txt", "/a/alpha.txt", "/a/mu.txt"}
+
+	got, err := SortPathsByComponents(input)
+	require.NoError(t, err)
+	require.Equal(t, []string{"/a/alpha.txt", "/a/mu.txt", "/a/zeta.txt"}, got)
+}
+
+func TestListPathInDirSortedByComponents(t *testing.T) {
+	root := t.TempDir()
+	mustWrite(t, filepath.Join(root, "top.txt"), "x")
+	mustWrite(t, filepath.Join(root, "sub", "mid.txt"), "x")
+	mustWrite(t, filepath.Join(root, "sub", "deep", "leaf.txt"), "x")
+
+	got, err := ListPathInDirSortedByComponents(root, true)
+	require.NoError(t, err)
+
+	// Expect shallowest entries first; root itself ("." after Rel) is included.
+	require.Equal(t, ".", got[0])
+	require.Contains(t, got, "top.txt")
+	require.Contains(t, got, filepath.Join("sub", "deep", "leaf.txt"))
+	// Deepest entry must come last.
+	require.Equal(t, filepath.Join("sub", "deep", "leaf.txt"), got[len(got)-1])
+}
+
+func mustWrite(t *testing.T, pth, content string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(filepath.Dir(pth), 0o755))
+	require.NoError(t, os.WriteFile(pth, []byte(content), 0o644))
+}


### PR DESCRIPTION
## Summary

- Migrates v1 `pathutil` filter + sortable-path helpers to v2 under `pathutil/`.
- New v2 API walks `fs.FS` with `FilterFunc(pth, fs.DirEntry) (bool, error)` and 10 filter factories.
- Ships v1-compat adapters (`FilterPaths([]string, ...)`, `ListEntries(dir, ...)`) so existing callers migrate by import-path rename only.
- Fixes two bugs carried over from the `poc-pathfilter` POC: `SkipDirectoryName` used `filepath.SplitList` (env-var list splitter, not path components) and `DirectoryContainsFile` used `os.Lstat` on fs-root-relative paths (broken unless cwd == fs root). Both now use `fs.FS` consistently.

### Public API

**v2 primary (fs.FS-based):**
- `FilterFS(fs.FS, ...FilterFunc) ([]string, error)`
- Factories: `BaseFilter`, `ExtensionFilter`, `RegexpFilter`, `ComponentFilter`, `ComponentWithExtensionFilter`, `IsDirectoryFilter`, `InDirectoryFilter`, `SkipDirectoryNameFilter`, `DirectoryContainsFileFilter(fsys, name)`, `FileContainsFilter(fsys, content)`

**v1-compat adapters:**
- `FilterPaths([]string, ...FilterFunc) ([]string, error)` — stat-per-path, preserves input order
- `ListEntries(dir string, ...FilterFunc) ([]string, error)` — non-recursive, returns absolute paths

**Sortable path:**
- `SortablePath`, `NewSortablePath`, `BySortablePathComponents`, `SortPathsByComponents`, `ListPathInDirSortedByComponents`

### Out of scope

Per the migration status doc the ticket references, only filters + sorting were missing from v2 `pathutil`. Not migrated (unused or intentionally dropped): `NormalizedOSTempDirPath`, `CurrentWorkingDirectoryAbsolutePath`, `UserHomeDir`, `EnsureDirExist`, `ExpandTilde`, `IsRelativePath`, `GetFileName`, `PathCheckAndInfos`, `RevokableChangeDir`, `ChangeDirForFunction`.

## Test plan

- [x] `go test ./pathutil/...` — all new + existing pathutil tests pass
- [x] `go test ./...` — full repo tests pass
- [x] `go vet ./...` clean
- [ ] Validate end-to-end with one v1 caller (e.g. go-xcode v1 `pathfilters`, steps-fastlane, steps-cocoapods-install) per parent ticket STEP-2134 AC

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## End-to-end validation

Draft consumer PR pinning `go-utils/v2` to this branch so CI exercises the new v2 pathutil filters:

- [bitrise-steplib/steps-cocoapods-install#113](https://github.com/bitrise-steplib/steps-cocoapods-install/pull/113) — migrates `main.go` Podfile discovery from v1 pathutil filters + sort to v2. Inlines five `go-xcode/pathfilters` entries as v2 factories. `AbsPath` / `IsPathExists` stay on v1 (out of scope). Initial attempt against `steps-fastlane` was closed — that step's e2e is blocked by an unrelated expired codesigning cert.

