### PR TITLE
[STEP-2145] Migrate urlutil to v2

### DIFF
--- a/urlutil/urlutil.go
+++ b/urlutil/urlutil.go
@@ -1,0 +1,50 @@
+package urlutil
+
+import (
+	"errors"
+	"net/url"
+	"strings"
+)
+
+// Join concatenates URL path elements with slash separators. The first
+// element must be an absolute URL carrying both scheme and host; subsequent
+// elements are appended as path segments. Leading and trailing slashes on
+// intermediate elements are normalized away. A trailing slash on the last
+// element is preserved.
+func Join(elems ...string) (string, error) {
+	if len(elems) < 1 {
+		return "", errors.New("No elements defined to Join")
+	}
+
+	u, err := url.Parse(elems[0])
+	if err != nil {
+		return "", err
+	}
+	if u.Scheme == "" {
+		return "", errors.New("No Scheme defined")
+	}
+	if u.Host == "" {
+		return "", errors.New("No Host defined")
+	}
+
+	var b strings.Builder
+	b.WriteString(u.Scheme)
+	b.WriteString("://")
+	b.WriteString(u.Host)
+	if firstPath := strings.Trim(u.Path, "/"); firstPath != "" {
+		b.WriteByte('/')
+		b.WriteString(firstPath)
+	}
+
+	lastIdx := len(elems) - 1
+	for i := 1; i < len(elems); i++ {
+		seg := strings.TrimLeft(elems[i], "/")
+		if i != lastIdx {
+			seg = strings.TrimRight(seg, "/")
+		}
+		b.WriteByte('/')
+		b.WriteString(seg)
+	}
+
+	return b.String(), nil
+}

--- a/urlutil/urlutil_test.go
+++ b/urlutil/urlutil_test.go
@@ -1,0 +1,166 @@
+package urlutil
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestJoin(t *testing.T) {
+	tests := []struct {
+		name     string
+		parts    []string
+		expected string
+	}{
+		{
+			name:     "single segment",
+			parts:    []string{"https://bitrise.io", "something"},
+			expected: "https://bitrise.io/something",
+		},
+		{
+			name:     "nested segment",
+			parts:    []string{"https://bitrise.io", "something/a"},
+			expected: "https://bitrise.io/something/a",
+		},
+		{
+			name:     "deeper nested segment",
+			parts:    []string{"https://bitrise.io", "something/a/b"},
+			expected: "https://bitrise.io/something/a/b",
+		},
+		{
+			name:     "preserves trailing slash on last segment",
+			parts:    []string{"https://bitrise.io", "something/a/b/"},
+			expected: "https://bitrise.io/something/a/b/",
+		},
+
+		{
+			name:     "strips leading slash on second element",
+			parts:    []string{"https://bitrise.io", "/something"},
+			expected: "https://bitrise.io/something",
+		},
+		{
+			name:     "strips leading slash, keeps inner",
+			parts:    []string{"https://bitrise.io", "/something/a"},
+			expected: "https://bitrise.io/something/a",
+		},
+		{
+			name:     "strips leading slash, keeps depth",
+			parts:    []string{"https://bitrise.io", "/something/a/b"},
+			expected: "https://bitrise.io/something/a/b",
+		},
+		{
+			name:     "strips leading slash, preserves trailing",
+			parts:    []string{"https://bitrise.io", "/something/a/b/"},
+			expected: "https://bitrise.io/something/a/b/",
+		},
+
+		{
+			name:     "trailing slash on host",
+			parts:    []string{"https://bitrise.io/", "/something"},
+			expected: "https://bitrise.io/something",
+		},
+		{
+			name:     "trailing slash on host with nested segment",
+			parts:    []string{"https://bitrise.io/", "/something/a"},
+			expected: "https://bitrise.io/something/a",
+		},
+		{
+			name:     "trailing slash on host with deeper segment",
+			parts:    []string{"https://bitrise.io/", "/something/a/b"},
+			expected: "https://bitrise.io/something/a/b",
+		},
+		{
+			name:     "trailing slash on host preserves trailing slash on last",
+			parts:    []string{"https://bitrise.io/", "/something/a/b/"},
+			expected: "https://bitrise.io/something/a/b/",
+		},
+
+		{
+			name:     "double slashes are collapsed",
+			parts:    []string{"https://bitrise.io//", "//something"},
+			expected: "https://bitrise.io/something",
+		},
+		{
+			name:     "double slashes collapsed, nested segment",
+			parts:    []string{"https://bitrise.io//", "//something/a"},
+			expected: "https://bitrise.io/something/a",
+		},
+		{
+			name:     "double slashes collapsed, deeper segment",
+			parts:    []string{"https://bitrise.io//", "//something/a/b"},
+			expected: "https://bitrise.io/something/a/b",
+		},
+		{
+			name:     "double slashes collapsed, trailing slash preserved",
+			parts:    []string{"https://bitrise.io//", "//something/a/b/"},
+			expected: "https://bitrise.io/something/a/b/",
+		},
+
+		{
+			name:     "multiple segments with host path",
+			parts:    []string{"https://bitrise-steplib-collection.s3.amazonaws.com/steps", "activate-ssh-key", "assets", "icon.svg"},
+			expected: "https://bitrise-steplib-collection.s3.amazonaws.com/steps/activate-ssh-key/assets/icon.svg",
+		},
+		{
+			name:     "multiple segments with trailing slash on host",
+			parts:    []string{"https://bitrise-steplib-collection.s3.amazonaws.com/steps/", "activate-ssh-key", "assets", "icon.svg"},
+			expected: "https://bitrise-steplib-collection.s3.amazonaws.com/steps/activate-ssh-key/assets/icon.svg",
+		},
+		{
+			name:     "multiple segments, one leading slash",
+			parts:    []string{"https://bitrise-steplib-collection.s3.amazonaws.com/steps/", "/activate-ssh-key", "assets", "icon.svg"},
+			expected: "https://bitrise-steplib-collection.s3.amazonaws.com/steps/activate-ssh-key/assets/icon.svg",
+		},
+		{
+			name:     "multiple segments, two leading slashes",
+			parts:    []string{"https://bitrise-steplib-collection.s3.amazonaws.com/steps/", "/activate-ssh-key", "/assets", "icon.svg"},
+			expected: "https://bitrise-steplib-collection.s3.amazonaws.com/steps/activate-ssh-key/assets/icon.svg",
+		},
+		{
+			name:     "multiple segments, all leading slashes",
+			parts:    []string{"https://bitrise-steplib-collection.s3.amazonaws.com/steps/", "/activate-ssh-key", "/assets", "/icon.svg"},
+			expected: "https://bitrise-steplib-collection.s3.amazonaws.com/steps/activate-ssh-key/assets/icon.svg",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := Join(tc.parts...)
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, got)
+		})
+	}
+}
+
+func TestJoin_errors(t *testing.T) {
+	tests := []struct {
+		name    string
+		parts   []string
+		wantErr string
+	}{
+		{
+			name:    "no elements",
+			parts:   []string{},
+			wantErr: "No elements defined to Join",
+		},
+		{
+			name:    "missing host",
+			parts:   []string{"https://", "bitrise.io"},
+			wantErr: "No Host defined",
+		},
+		{
+			name:    "missing scheme",
+			parts:   []string{"bitrise.io", "something"},
+			wantErr: "No Scheme defined",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := Join(tc.parts...)
+			require.Error(t, err)
+			require.Equal(t, tc.wantErr, err.Error())
+			require.Equal(t, "", got)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Adds the v1 `urlutil` package to v2: a single exported function `Join(elems ...string) (string, error)` that concatenates URL path elements with slash-separator normalization.
- Cleans up the v1 implementation while preserving observable behavior — all v1 test cases carry over verbatim, plus explicit error cases.

### Cleanup vs v1

- Replaces recursive `clearPrefix` / `clearSuffix` helpers with `strings.TrimLeft` / `strings.TrimRight` / `strings.Trim`.
- Uses `strings.Builder` for path concatenation instead of string concatenation in a loop.
- Renames local `url` variable to avoid shadowing the `net/url` package.
- Tests restructured as table-driven, separating success and error scenarios.

### Behavior (unchanged)

- First element must be an absolute URL with both scheme and host.
- Intermediate path segments: leading and trailing slashes are stripped.
- Last segment: only leading slashes stripped — **trailing slash preserved** (matches v1).
- Empty input → `"No elements defined to Join"`; missing scheme/host → matching v1 errors.

### Callers (per migration status doc + code search)

- `bitrise-io/stepman` (util.go)
- `bitrise-io/codesigndoc` (3 files)
- 2 steps using go-utils v1

Callers migrate by import-path rename only.

## Test plan

- [x] `go test ./urlutil/...` — all cases pass
- [x] `go test ./...` — repo-wide tests pass
- [x] `go vet ./...` clean
- [ ] Validate end-to-end with one v1 caller (stepman or a step) per parent ticket STEP-2134 AC

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## End-to-end validation

Draft consumer PR pinning `go-utils/v2` to this branch so CI exercises the new v2 urlutil:

- [bitrise-steplib/steps-deploy-to-bitrise-io#260](https://github.com/bitrise-steplib/steps-deploy-to-bitrise-io/pull/260) — swaps `uploaders/common.go` import path to `go-utils/v2/urlutil`; `urlutil.Join(...)` call sites unchanged.
