### PR TITLE
[STEP-2146] Migrate pretty to v2

### DIFF
--- a/pretty/pretty.go
+++ b/pretty/pretty.go
@@ -1,0 +1,16 @@
+package pretty
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Object returns the indented JSON representation of o. If o cannot be
+// marshaled as JSON, Object falls back to Go's default fmt format.
+func Object(o any) string {
+	b, err := json.MarshalIndent(o, "", "\t")
+	if err != nil {
+		return fmt.Sprint(o)
+	}
+	return string(b)
+}

--- a/pretty/pretty_test.go
+++ b/pretty/pretty_test.go
@@ -1,0 +1,50 @@
+package pretty
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestObject_map(t *testing.T) {
+	o := map[string]any{
+		"key": "value",
+		"slice_key": []string{
+			"item1",
+			"item2",
+		},
+	}
+	const want = `{
+	"key": "value",
+	"slice_key": [
+		"item1",
+		"item2"
+	]
+}`
+	require.Equal(t, want, Object(o))
+}
+
+func TestObject_primitive(t *testing.T) {
+	require.Equal(t, `"hello"`, Object("hello"))
+	require.Equal(t, `42`, Object(42))
+	require.Equal(t, `null`, Object(nil))
+}
+
+func TestObject_struct(t *testing.T) {
+	type payload struct {
+		Name  string `json:"name"`
+		Count int    `json:"count"`
+	}
+	const want = `{
+	"name": "bitrise",
+	"count": 3
+}`
+	require.Equal(t, want, Object(payload{Name: "bitrise", Count: 3}))
+}
+
+func TestObject_unmarshalableFallsBackToFmt(t *testing.T) {
+	// NaN cannot be marshaled as JSON; Object must fall back to fmt.Sprint.
+	got := Object(math.NaN())
+	require.Equal(t, "NaN", got)
+}


### PR DESCRIPTION
## Summary

- Adds the v1 \`pretty\` package to v2. Single exported function \`Object(o any) string\` returns the indented JSON representation of its input; falls back to \`fmt.Sprint\` when the value cannot be marshaled as JSON (e.g. \`NaN\`, channels, functions).

### Cleanup vs v1

- \`interface{}\` → \`any\`.
- Tests expanded from a single map case to also cover primitives, structs, and the \`fmt\` fallback path (\`math.NaN()\`).

### Known callers (per migration status doc + code search)

- \`bitrise-steplib/steps-deploy-to-bitrise-io\` (test result handling)
- \`bitrise-io/go-android/v2\` (already on go-utils v2 — lets it drop its last v1 dep on \`pretty\`)

Callers migrate by import-path rename only.

## Test plan

- [x] \`go test ./pretty/...\` — all cases pass
- [x] \`go test ./...\` — repo-wide tests pass
- [x] \`go vet ./...\` clean
- [ ] End-to-end validation with one caller (follow-up draft PR pinning \`go-utils/v2\` to this branch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## End-to-end validation

Draft consumer PR pinning `go-utils/v2` to this branch so CI exercises the new v2 pretty:

- [bitrise-steplib/bitrise-step-export-universal-apk#27](https://github.com/bitrise-steplib/bitrise-step-export-universal-apk/pull/27) — swaps `apkexporter/file_name.go` import path to `go-utils/v2/pretty`; `pretty.Object(...)` call sites unchanged.
