### PR TITLE
[STEP-2148] Migrate httputil to v2

### DIFF
--- a/httputil/httputil.go
+++ b/httputil/httputil.go
@@ -1,0 +1,46 @@
+package httputil
+
+import (
+	"net/http"
+	"net/http/httputil"
+
+	"github.com/bitrise-io/go-utils/v2/log"
+)
+
+// PrintRequest dumps request (including body) to logger at debug level.
+// A nil request is a no-op.
+func PrintRequest(logger log.Logger, request *http.Request) error {
+	if request == nil {
+		return nil
+	}
+
+	dump, err := httputil.DumpRequest(request, true)
+	if err != nil {
+		return err
+	}
+
+	logger.Debugf("%s", dump)
+	return nil
+}
+
+// PrintResponse dumps response (including body) to logger at debug level.
+// A nil response is a no-op.
+func PrintResponse(logger log.Logger, response *http.Response) error {
+	if response == nil {
+		return nil
+	}
+
+	dump, err := httputil.DumpResponse(response, true)
+	if err != nil {
+		return err
+	}
+
+	logger.Debugf("%s", dump)
+	return nil
+}
+
+// IsUserFixable reports whether statusCode indicates an error the caller
+// can correct (bad request or unauthorized).
+func IsUserFixable(statusCode int) bool {
+	return statusCode == http.StatusBadRequest || statusCode == http.StatusUnauthorized
+}

--- a/httputil/httputil_test.go
+++ b/httputil/httputil_test.go
@@ -1,0 +1,80 @@
+package httputil
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/bitrise-io/go-utils/v2/log"
+	"github.com/stretchr/testify/require"
+)
+
+// debugCapture collects Debugf output; other Logger methods are no-ops.
+type debugCapture struct {
+	log.Logger
+	buf bytes.Buffer
+}
+
+func (d *debugCapture) Debugf(format string, v ...any) {
+	fmt.Fprintf(&d.buf, format, v...)
+}
+
+func TestIsUserFixable(t *testing.T) {
+	require.True(t, IsUserFixable(http.StatusBadRequest))
+	require.True(t, IsUserFixable(http.StatusUnauthorized))
+	require.False(t, IsUserFixable(http.StatusOK))
+	require.False(t, IsUserFixable(http.StatusForbidden))
+	require.False(t, IsUserFixable(http.StatusInternalServerError))
+}
+
+func TestPrintRequest_nil(t *testing.T) {
+	logger := &debugCapture{}
+	require.NoError(t, PrintRequest(logger, nil))
+	require.Empty(t, logger.buf.String())
+}
+
+func TestPrintRequest_dumpsMethodPathAndBody(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/v1/widgets", strings.NewReader(`{"name":"foo"}`))
+	req.Header.Set("X-Test", "yes")
+
+	logger := &debugCapture{}
+	require.NoError(t, PrintRequest(logger, req))
+
+	out := logger.buf.String()
+	require.Contains(t, out, "POST /v1/widgets")
+	require.Contains(t, out, "X-Test: yes")
+	require.Contains(t, out, `{"name":"foo"}`)
+}
+
+func TestPrintResponse_nil(t *testing.T) {
+	logger := &debugCapture{}
+	require.NoError(t, PrintResponse(logger, nil))
+	require.Empty(t, logger.buf.String())
+}
+
+func TestPrintResponse_dumpsStatusHeadersAndBody(t *testing.T) {
+	resp := &http.Response{
+		Status:     "201 Created",
+		StatusCode: http.StatusCreated,
+		Proto:      "HTTP/1.1",
+		ProtoMajor: 1,
+		ProtoMinor: 1,
+		Header: http.Header{
+			"Content-Type": {"application/json"},
+		},
+		Body:          io.NopCloser(strings.NewReader(`{"id":1}`)),
+		ContentLength: int64(len(`{"id":1}`)),
+	}
+
+	logger := &debugCapture{}
+	require.NoError(t, PrintResponse(logger, resp))
+
+	out := logger.buf.String()
+	require.Contains(t, out, "201 Created")
+	require.Contains(t, out, "Content-Type: application/json")
+	require.Contains(t, out, `{"id":1}`)
+}


### PR DESCRIPTION
## Summary

- Adds the v1 \`httputil\` package to v2 with a small API update to fit the interface-based v2 \`log\` package.

### Public API

- \`PrintRequest(logger log.Logger, request *http.Request) error\`
- \`PrintResponse(logger log.Logger, response *http.Response) error\`
- \`IsUserFixable(statusCode int) bool\`

### API change vs v1

v1 \`PrintRequest\` / \`PrintResponse\` relied on the package-level \`log.Debugf\`. v2 \`log\` exposes a \`Logger\` interface instead, so both functions take a \`log.Logger\` as the first argument now. Known caller (\`go-xcode/v2\` autocodesign) already holds a logger and will pass it through.

### Cleanup

- \`IsUserFixable\` uses \`http.StatusBadRequest\` / \`http.StatusUnauthorized\` constants instead of bare \`400 || 401\`. Behavior unchanged.
- \`interface{}\` → \`any\` in the test helper.

### Callers (per migration status doc)

- \`bitrise-io/go-xcode/v2\` autocodesign — only known caller. Migrating this unblocks \`go-xcode/v2\` from its last v1 dependency on \`httputil\`.

## Test plan

- [x] \`go test ./httputil/...\` — all cases pass (IsUserFixable, nil inputs, dump content for methods/headers/bodies)
- [x] \`go test ./...\` — repo-wide tests pass
- [x] \`go vet ./...\` clean
- [ ] End-to-end validation with one caller (follow-up draft PR pinning \`go-utils/v2\` to this branch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## End-to-end validation

Draft consumer PR pinning `go-utils/v2` to this branch so CI exercises the new v2 httputil:

- [bitrise-io/go-xcode#324](https://github.com/bitrise-io/go-xcode/pull/324) — swaps `autocodesign/devportalclient/appstoreconnect/appstoreconnect.go` to v2 httputil and passes `c.logger` to `PrintRequest` / `PrintResponse`.
