### PR TITLE
[STEP-2149] Migrate templateutil to v2

### DIFF
--- a/templateutil/templateutil.go
+++ b/templateutil/templateutil.go
@@ -1,0 +1,71 @@
+// Package templateutil provides helpers for evaluating Go text/template
+// snippets against an inventory value, with optional custom delimiters
+// and template options.
+package templateutil
+
+import (
+	"bytes"
+	"text/template"
+)
+
+// evaluateTemplate parses and executes templateContent against inventory
+// using the provided FuncMap, delimiters, and options. Empty delimiters
+// fall back to the text/template defaults ("{{" and "}}").
+// See https://pkg.go.dev/text/template#Template.Option for the option set.
+func evaluateTemplate(
+	templateContent string,
+	inventory any,
+	funcs template.FuncMap,
+	delimLeft, delimRight string,
+	templateOptions []string,
+) (string, error) {
+	tmpl := template.New("").Funcs(funcs).Delims(delimLeft, delimRight)
+	if len(templateOptions) > 0 {
+		tmpl = tmpl.Option(templateOptions...)
+	}
+
+	tmpl, err := tmpl.Parse(templateContent)
+	if err != nil {
+		return "", err
+	}
+
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, inventory); err != nil {
+		return "", err
+	}
+	return buf.String(), nil
+}
+
+// EvaluateTemplateStringToStringWithDelimiterAndOpts evaluates
+// templateContent with custom delimiters and template options applied.
+// See https://pkg.go.dev/text/template#Template.Option for the option set.
+func EvaluateTemplateStringToStringWithDelimiterAndOpts(
+	templateContent string,
+	inventory any,
+	funcs template.FuncMap,
+	delimLeft, delimRight string,
+	templateOptions []string,
+) (string, error) {
+	return evaluateTemplate(templateContent, inventory, funcs, delimLeft, delimRight, templateOptions)
+}
+
+// EvaluateTemplateStringToStringWithDelimiter evaluates templateContent
+// with custom delimiters and no template options.
+func EvaluateTemplateStringToStringWithDelimiter(
+	templateContent string,
+	inventory any,
+	funcs template.FuncMap,
+	delimLeft, delimRight string,
+) (string, error) {
+	return evaluateTemplate(templateContent, inventory, funcs, delimLeft, delimRight, nil)
+}
+
+// EvaluateTemplateStringToString evaluates templateContent using the
+// default text/template delimiters and no template options.
+func EvaluateTemplateStringToString(
+	templateContent string,
+	inventory any,
+	funcs template.FuncMap,
+) (string, error) {
+	return evaluateTemplate(templateContent, inventory, funcs, "", "", nil)
+}

--- a/templateutil/templateutil_test.go
+++ b/templateutil/templateutil_test.go
@@ -1,0 +1,126 @@
+package templateutil
+
+import (
+	"testing"
+	"text/template"
+
+	"github.com/stretchr/testify/require"
+)
+
+type emptyInventory struct{}
+
+type inventory struct {
+	Material string
+	Count    uint
+}
+
+func TestEvaluateTemplateStringToString(t *testing.T) {
+	t.Run("empty template, empty inventory", func(t *testing.T) {
+		got, err := EvaluateTemplateStringToString("", emptyInventory{}, template.FuncMap{})
+		require.NoError(t, err)
+		require.Equal(t, "", got)
+	})
+
+	t.Run("empty template, populated inventory", func(t *testing.T) {
+		got, err := EvaluateTemplateStringToString("", inventory{Material: "wool", Count: 17}, template.FuncMap{})
+		require.NoError(t, err)
+		require.Equal(t, "", got)
+	})
+
+	t.Run("plain string without template expressions", func(t *testing.T) {
+		got, err := EvaluateTemplateStringToString("no template string", inventory{Material: "wool", Count: 17}, template.FuncMap{})
+		require.NoError(t, err)
+		require.Equal(t, "no template string", got)
+	})
+
+	t.Run("missing field on empty inventory returns error", func(t *testing.T) {
+		_, err := EvaluateTemplateStringToString(
+			"{{.Count}} items are made of {{.Material}}",
+			emptyInventory{}, template.FuncMap{},
+		)
+		require.Error(t, err)
+	})
+
+	t.Run("simple substitution with default delimiters", func(t *testing.T) {
+		got, err := EvaluateTemplateStringToString(
+			"{{.Count}} items are made of {{.Material}}",
+			inventory{Material: "wool", Count: 17}, template.FuncMap{},
+		)
+		require.NoError(t, err)
+		require.Equal(t, "17 items are made of wool", got)
+	})
+
+	t.Run("custom FuncMap is available inside template", func(t *testing.T) {
+		funcs := template.FuncMap{
+			"isOne": func(i int) bool { return i == 1 },
+		}
+		got, err := EvaluateTemplateStringToString(
+			"{{if isOne 1}}yes{{else}}no{{end}}",
+			emptyInventory{}, funcs,
+		)
+		require.NoError(t, err)
+		require.Equal(t, "yes", got)
+	})
+}
+
+func TestEvaluateTemplateStringToStringWithDelimiter(t *testing.T) {
+	t.Run("custom delimiters substitute", func(t *testing.T) {
+		got, err := EvaluateTemplateStringToStringWithDelimiter(
+			"<<.Count>> items are made of <<.Material>>",
+			inventory{Material: "wool", Count: 17}, template.FuncMap{},
+			"<<", ">>",
+		)
+		require.NoError(t, err)
+		require.Equal(t, "17 items are made of wool", got)
+	})
+
+	t.Run("default markers are literal when custom delimiters set", func(t *testing.T) {
+		got, err := EvaluateTemplateStringToStringWithDelimiter(
+			"{{.Count}} items are made of {{.Material}}",
+			inventory{Material: "wool", Count: 17}, template.FuncMap{},
+			"<<", ">>",
+		)
+		require.NoError(t, err)
+		require.Equal(t, "{{.Count}} items are made of {{.Material}}", got)
+	})
+}
+
+func TestEvaluateTemplateStringToStringWithDelimiterAndOpts(t *testing.T) {
+	t.Run("no options, custom delimiters", func(t *testing.T) {
+		got, err := EvaluateTemplateStringToStringWithDelimiterAndOpts(
+			"<<.Count>> items are made of <<.Material>>",
+			inventory{Material: "wool", Count: 17}, template.FuncMap{},
+			"<<", ">>",
+			[]string{},
+		)
+		require.NoError(t, err)
+		require.Equal(t, "17 items are made of wool", got)
+	})
+
+	t.Run("missingkey=error surfaces missing field as error", func(t *testing.T) {
+		got, err := EvaluateTemplateStringToStringWithDelimiterAndOpts(
+			"<<.Undefined>> items are made of <<.Material>>",
+			inventory{Material: "wool", Count: 17}, template.FuncMap{},
+			"<<", ">>",
+			[]string{"missingkey=error"},
+		)
+		require.EqualError(t, err, `template: :1:2: executing "" at <.Undefined>: can't evaluate field Undefined in type templateutil.inventory`)
+		require.Equal(t, "", got)
+	})
+
+	t.Run("missingkey=error also applies with default delimiters", func(t *testing.T) {
+		got, err := EvaluateTemplateStringToStringWithDelimiterAndOpts(
+			"{{.UndefinedDefDelim}} items are made of {{.Material}}",
+			inventory{Material: "wool", Count: 17}, template.FuncMap{},
+			"", "",
+			[]string{"missingkey=error"},
+		)
+		require.EqualError(t, err, `template: :1:2: executing "" at <.UndefinedDefDelim>: can't evaluate field UndefinedDefDelim in type templateutil.inventory`)
+		require.Equal(t, "", got)
+	})
+}
+
+func TestEvaluateTemplateStringToString_parseError(t *testing.T) {
+	_, err := EvaluateTemplateStringToString("{{ unterminated", inventory{Material: "wool", Count: 17}, template.FuncMap{})
+	require.Error(t, err)
+}


### PR DESCRIPTION
## Summary

Ports the v1 \`templateutil\` package to v2. Four entry points, matching v1 names:

- \`EvaluateTemplateStringToString(content, inventory, funcs)\`
- \`EvaluateTemplateStringToStringWithDelimiter(content, inventory, funcs, delimLeft, delimRight)\`
- \`EvaluateTemplateStringToStringWithDelimiterAndOpts(content, inventory, funcs, delimLeft, delimRight, options)\`
- \`evaluateTemplate(...)\` — internal helper

### Cleanup vs v1

- \`interface{}\` → \`any\` on every signature.
- Zero-option path passes \`nil\` instead of \`[]string{}\` to the helper.
- Tests reorganized into \`t.Run\` sub-tests and extended with a parse-error case.

### Callers (per migration status doc)

- \`bitrise-io/bitrise-plugins-step\` — only known caller. Migrates by import-path rename only.

## Test plan

- [x] \`go test ./templateutil/...\` — all cases pass
- [x] \`go test ./...\` — repo-wide tests pass
- [x] \`go vet ./...\` clean
- [ ] End-to-end validation with one caller (follow-up draft PR pinning \`go-utils/v2\` to this branch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## End-to-end validation

Draft consumer PR pinning `go-utils/v2` to this branch so CI exercises the new v2 templateutil:

- [bitrise-io/bitrise-plugins-step#53](https://github.com/bitrise-io/bitrise-plugins-step/pull/53) — swaps `create/create.go` import path to `go-utils/v2/templateutil`; call site unchanged.
