### PR TITLE
Clarify ziputil behavior with comments and tests

### DIFF
--- a/ziputil/ziputil.go
+++ b/ziputil/ziputil.go
@@ -34,9 +34,9 @@ func ZipDir(sourceDirPth, destinationZipPth string, isContentOnly bool) error {
 }
 
 // ZipDirs zips multiple directories into a single archive, each under its own basename.
-// When two entries in sourceDirPths share the same basename (e.g. "/a/shared" and "/b/shared"),
-// their contents are merged via rsync (-ar); the outcome for conflicting filenames depends
-// on rsync's overwrite rules and the files' mtimes at the time of the call.
+// When two entries in sourceDirPths share the same basename (e.g. "/a/shared" and
+// "/b/shared"), their contents are merged; files unique to either are preserved,
+// and conflicting filenames are overwritten by entries later in sourceDirPths.
 // If the temporary directory cleanup fails, the process is terminated via log.Fatal.
 func ZipDirs(sourceDirPths []string, destinationZipPth string) error {
 	for _, path := range sourceDirPths {
@@ -70,7 +70,8 @@ func ZipDirs(sourceDirPths []string, destinationZipPth string) error {
 
 func internalZipDir(destinationZipPth, zipTarget, workDir string) error {
 	// -r: recurse into directories
-	// -T: test archive integrity after creation; deletes the archive on failure
+	// -T: test the temp archive with unzip before overwriting the destination;
+	//     on failure the destination is left in its prior state
 	// -y: store symlinks as symlinks instead of following them
 	cmd := command.New("/usr/bin/zip", "-rTy", destinationZipPth, zipTarget)
 	cmd.SetDir(workDir)
@@ -99,7 +100,8 @@ func ZipFiles(sourceFilePths []string, destinationZipPth string) error {
 		}
 	}
 
-	// -T: test archive integrity after creation; deletes the archive on failure
+	// -T: test the temp archive with unzip before overwriting the destination;
+	//     on failure the destination is left in its prior state
 	// -y: store symlinks as symlinks instead of following them
 	// -j: junk directory paths, store files under their base names only
 	parameters := []string{"-Tyj", destinationZipPth}

--- a/ziputil/ziputil.go
+++ b/ziputil/ziputil.go
@@ -10,7 +10,10 @@ import (
 	"github.com/bitrise-io/go-utils/pathutil"
 )
 
-// ZipDir ...
+// ZipDir zips sourceDirPth into destinationZipPth.
+// isContentOnly=false: archive contains the directory under its own basename (e.g. "mydir/file.txt").
+// isContentOnly=true: archive contains the directory's contents directly (e.g. "file.txt").
+// Directory modification times are preserved. Symlinks are stored as symlinks (not followed).
 func ZipDir(sourceDirPth, destinationZipPth string, isContentOnly bool) error {
 	if exist, err := pathutil.IsDirExists(sourceDirPth); err != nil {
 		return err
@@ -30,7 +33,11 @@ func ZipDir(sourceDirPth, destinationZipPth string, isContentOnly bool) error {
 
 }
 
-// ZipDirs ...
+// ZipDirs zips multiple directories into a single archive, each under its own basename.
+// When two entries in sourceDirPths share the same basename (e.g. "/a/shared" and "/b/shared"),
+// their contents are merged: files unique to either directory are preserved, and files
+// with the same name are resolved in favour of the last directory in the list.
+// If the temporary directory cleanup fails, the process is terminated via log.Fatal.
 func ZipDirs(sourceDirPths []string, destinationZipPth string) error {
 	for _, path := range sourceDirPths {
 		if exist, err := pathutil.IsDirExists(path); err != nil {
@@ -62,9 +69,9 @@ func ZipDirs(sourceDirPths []string, destinationZipPth string) error {
 }
 
 func internalZipDir(destinationZipPth, zipTarget, workDir string) error {
-	// -r - Travel the directory structure recursively
-	// -T - Test the integrity of the new zip file
-	// -y - Store symbolic links as such in the zip archive, instead of compressing and storing the file referred to by the link
+	// -r: recurse into directories
+	// -T: test archive integrity after creation; deletes the archive on failure
+	// -y: store symlinks as symlinks instead of following them
 	cmd := command.New("/usr/bin/zip", "-rTy", destinationZipPth, zipTarget)
 	cmd.SetDir(workDir)
 	if out, err := cmd.RunAndReturnTrimmedCombinedOutput(); err != nil {
@@ -74,12 +81,15 @@ func internalZipDir(destinationZipPth, zipTarget, workDir string) error {
 	return nil
 }
 
-// ZipFile ...
+// ZipFile zips a single file into destinationZipPth.
 func ZipFile(sourceFilePth, destinationZipPth string) error {
 	return ZipFiles([]string{sourceFilePth}, destinationZipPth)
 }
 
-// ZipFiles ...
+// ZipFiles zips multiple files into destinationZipPth without preserving directory structure.
+// Each file is stored under its base name only (-j junk paths).
+// If two source files share the same base name, the command fails and the destination
+// file is not created.
 func ZipFiles(sourceFilePths []string, destinationZipPth string) error {
 	for _, path := range sourceFilePths {
 		if exist, err := pathutil.IsPathExists(path); err != nil {
@@ -89,9 +99,9 @@ func ZipFiles(sourceFilePths []string, destinationZipPth string) error {
 		}
 	}
 
-	// -T - Test the integrity of the new zip file
-	// -y - Store symbolic links as such in the zip archive, instead of compressing and storing the file referred to by the link
-	// -j - Do not recreate the directory structure inside the zip. Kind of equivalent of copying all the files in one folder and zipping it.
+	// -T: test archive integrity after creation; deletes the archive on failure
+	// -y: store symlinks as symlinks instead of following them
+	// -j: junk directory paths, store files under their base names only
 	parameters := []string{"-Tyj", destinationZipPth}
 	parameters = append(parameters, sourceFilePths...)
 	cmd := command.New("/usr/bin/zip", parameters...)
@@ -102,7 +112,10 @@ func ZipFiles(sourceFilePths []string, destinationZipPth string) error {
 	return nil
 }
 
-// UnZip ...
+// UnZip extracts the zip archive at zipPth into intoDir.
+// Entries with path-traversal components (e.g. "../../escape") are not rejected;
+// instead the system unzip strips those components, extracts the file inside intoDir,
+// and returns a non-zero exit code. The exact behaviour is macOS unzip version dependent.
 func UnZip(zip, intoDir string) error {
 	cmd := command.New("/usr/bin/unzip", zip, "-d", intoDir)
 	if out, err := cmd.RunAndReturnTrimmedCombinedOutput(); err != nil {

--- a/ziputil/ziputil.go
+++ b/ziputil/ziputil.go
@@ -35,8 +35,8 @@ func ZipDir(sourceDirPth, destinationZipPth string, isContentOnly bool) error {
 
 // ZipDirs zips multiple directories into a single archive, each under its own basename.
 // When two entries in sourceDirPths share the same basename (e.g. "/a/shared" and "/b/shared"),
-// their contents are merged: files unique to either directory are preserved, and files
-// with the same name are resolved in favour of the last directory in the list.
+// their contents are merged via rsync (-ar); the outcome for conflicting filenames depends
+// on rsync's overwrite rules and the files' mtimes at the time of the call.
 // If the temporary directory cleanup fails, the process is terminated via log.Fatal.
 func ZipDirs(sourceDirPths []string, destinationZipPth string) error {
 	for _, path := range sourceDirPths {
@@ -115,7 +115,7 @@ func ZipFiles(sourceFilePths []string, destinationZipPth string) error {
 // UnZip extracts the zip archive at zipPth into intoDir.
 // Entries with path-traversal components (e.g. "../../escape") are not rejected;
 // instead the system unzip strips those components, extracts the file inside intoDir,
-// and returns a non-zero exit code. The exact behaviour is macOS unzip version dependent.
+// and returns a non-zero exit code.
 func UnZip(zip, intoDir string) error {
 	cmd := command.New("/usr/bin/unzip", zip, "-d", intoDir)
 	if out, err := cmd.RunAndReturnTrimmedCombinedOutput(); err != nil {

--- a/ziputil/ziputil_test.go
+++ b/ziputil/ziputil_test.go
@@ -1,9 +1,11 @@
 package ziputil
 
 import (
+	"archive/zip"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/bitrise-io/go-utils/fileutil"
 	"github.com/bitrise-io/go-utils/pathutil"
@@ -401,4 +403,140 @@ func TestUnZipDirectory(t *testing.T) {
 		require.NoError(t, revokeFn())
 		// ---
 	}
+}
+
+// TestZipDirPreservesDirMtime verifies that directory entry modification times are stored
+// in the archive.
+func TestZipDirPreservesDirMtime(t *testing.T) {
+	tmpDir, err := pathutil.NormalizedOSTempDirPath("test")
+	require.NoError(t, err)
+
+	sourceDir := filepath.Join(tmpDir, "sourceDir")
+	require.NoError(t, os.MkdirAll(sourceDir, 0755))
+
+	knownTime := time.Date(2020, 1, 1, 12, 0, 0, 0, time.UTC)
+	require.NoError(t, os.Chtimes(sourceDir, knownTime, knownTime))
+
+	destinationZip := filepath.Join(tmpDir, "out.zip")
+	// isContentOnly=true so sourceDir/ is a direct top-level entry with a predictable name.
+	require.NoError(t, ZipDir(tmpDir, destinationZip, true))
+
+	r, err := zip.OpenReader(destinationZip)
+	require.NoError(t, err)
+	defer r.Close() //nolint:errcheck
+
+	var found bool
+	for _, f := range r.File {
+		if f.Name == "sourceDir/" {
+			found = true
+			stored := f.Modified.UTC()
+			require.Equal(t, knownTime.Year(), stored.Year())
+			require.Equal(t, knownTime.Month(), stored.Month())
+			require.Equal(t, knownTime.Day(), stored.Day())
+			break
+		}
+	}
+	require.True(t, found, "sourceDir/ entry not found in archive")
+}
+
+// TestZipDirsSameBasenamesMerge verifies the merge behaviour when two entries in
+// sourceDirPths share the same basename. Files unique to either directory are preserved;
+// conflicting files (same name) are resolved in favour of the last directory in the list.
+func TestZipDirsSameBasenamesMerge(t *testing.T) {
+	tmpDir, err := pathutil.NormalizedOSTempDirPath("test")
+	require.NoError(t, err)
+
+	// /a/shared and /b/shared share the basename "shared".
+	dirA := filepath.Join(tmpDir, "a", "shared")
+	dirB := filepath.Join(tmpDir, "b", "shared")
+	require.NoError(t, os.MkdirAll(dirA, 0755))
+	require.NoError(t, os.MkdirAll(dirB, 0755))
+
+	require.NoError(t, fileutil.WriteStringToFile(filepath.Join(dirA, "only_in_a.txt"), "from_a"))
+	require.NoError(t, fileutil.WriteStringToFile(filepath.Join(dirB, "only_in_b.txt"), "from_b"))
+	require.NoError(t, fileutil.WriteStringToFile(filepath.Join(dirA, "conflict.txt"), "first"))
+	require.NoError(t, fileutil.WriteStringToFile(filepath.Join(dirB, "conflict.txt"), "second"))
+
+	destinationZip := filepath.Join(tmpDir, "out.zip")
+	require.NoError(t, ZipDirs([]string{dirA, dirB}, destinationZip))
+
+	unzipDir, err := pathutil.NormalizedOSTempDirPath("unzip")
+	require.NoError(t, err)
+	require.NoError(t, UnZip(destinationZip, unzipDir))
+
+	// Files unique to each directory are both present.
+	onlyA, err := fileutil.ReadStringFromFile(filepath.Join(unzipDir, "shared", "only_in_a.txt"))
+	require.NoError(t, err)
+	require.Equal(t, "from_a", onlyA)
+
+	onlyB, err := fileutil.ReadStringFromFile(filepath.Join(unzipDir, "shared", "only_in_b.txt"))
+	require.NoError(t, err)
+	require.Equal(t, "from_b", onlyB)
+
+	// Conflicting file resolves to the last directory in the list.
+	conflict, err := fileutil.ReadStringFromFile(filepath.Join(unzipDir, "shared", "conflict.txt"))
+	require.NoError(t, err)
+	require.Equal(t, "second", conflict)
+}
+
+// TestZipFilesDuplicateBasenameNoOutputCreated verifies that when two source files share
+// the same base name, ZipFiles returns an error and does not create the destination file.
+func TestZipFilesDuplicateBasenameNoOutputCreated(t *testing.T) {
+	tmpDir, err := pathutil.NormalizedOSTempDirPath("test")
+	require.NoError(t, err)
+
+	dirA := filepath.Join(tmpDir, "a")
+	dirB := filepath.Join(tmpDir, "b")
+	require.NoError(t, os.MkdirAll(dirA, 0755))
+	require.NoError(t, os.MkdirAll(dirB, 0755))
+
+	require.NoError(t, fileutil.WriteStringToFile(filepath.Join(dirA, "file.txt"), "a"))
+	require.NoError(t, fileutil.WriteStringToFile(filepath.Join(dirB, "file.txt"), "b"))
+
+	destinationZip := filepath.Join(tmpDir, "out.zip")
+	require.Error(t, ZipFiles([]string{
+		filepath.Join(dirA, "file.txt"),
+		filepath.Join(dirB, "file.txt"),
+	}, destinationZip))
+
+	// The destination file must not be left behind after the failure.
+	exist, err := pathutil.IsPathExists(destinationZip)
+	require.NoError(t, err)
+	require.False(t, exist, "destination zip must not be created when duplicate base names are detected")
+}
+
+// TestUnZipZipSlipHandling verifies the behaviour for archives with path-traversal entries.
+// The system unzip strips the "../" components, extracts the file inside intoDir,
+// and returns a non-zero exit code (which UnZip surfaces as an error).
+func TestUnZipZipSlipHandling(t *testing.T) {
+	tmpDir, err := pathutil.NormalizedOSTempDirPath("test")
+	require.NoError(t, err)
+
+	evilZip := filepath.Join(tmpDir, "evil.zip")
+	zf, err := os.Create(evilZip)
+	require.NoError(t, err)
+	zw := zip.NewWriter(zf)
+	w, err := zw.CreateHeader(&zip.FileHeader{Name: "../../escape.txt", Method: zip.Store})
+	require.NoError(t, err)
+	_, err = w.Write([]byte("escaped"))
+	require.NoError(t, err)
+	require.NoError(t, zw.Close())
+	require.NoError(t, zf.Close())
+
+	destDir := filepath.Join(tmpDir, "dest")
+	require.NoError(t, os.MkdirAll(destDir, 0755))
+
+	// UnZip returns an error because unzip exits non-zero for path-traversal warnings.
+	err = UnZip(evilZip, destDir)
+	require.Error(t, err)
+
+	// Despite the error, the file is extracted inside destDir with the traversal stripped.
+	exist, statErr := pathutil.IsPathExists(filepath.Join(destDir, "escape.txt"))
+	require.NoError(t, statErr)
+	require.True(t, exist, "system unzip strips '../' and extracts inside dest")
+
+	// The file must not have escaped outside destDir.
+	escaped, statErr := pathutil.IsPathExists(filepath.Join(tmpDir, "escape.txt"))
+	require.NoError(t, statErr)
+	require.False(t, escaped, "file must not escape outside intoDir")
 }

--- a/ziputil/ziputil_test.go
+++ b/ziputil/ziputil_test.go
@@ -400,8 +400,11 @@ func TestUnZipZipSlipHandling(t *testing.T) {
 	require.NoError(t, statErr)
 	require.True(t, exist, "system unzip strips '../' and extracts inside dest")
 
-	// The file must not have escaped outside destDir.
-	escaped, statErr := pathutil.IsPathExists(filepath.Join(tmpDir, "escape.txt"))
+	// The file must not have escaped outside destDir. The entry has two "../" components
+	// and destDir is one level below tmpDir, so a real escape would land at the parent of
+	// tmpDir; that is the path to check.
+	escapeTarget := filepath.Join(filepath.Dir(tmpDir), "escape.txt")
+	escaped, statErr := pathutil.IsPathExists(escapeTarget)
 	require.NoError(t, statErr)
 	require.False(t, escaped, "file must not escape outside intoDir")
 }

--- a/ziputil/ziputil_test.go
+++ b/ziputil/ziputil_test.go
@@ -12,71 +12,34 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestZipFile(t *testing.T) {
-	tmpDir, err := pathutil.NormalizedOSTempDirPath("test")
-	require.NoError(t, err)
-
-	sourceFile := filepath.Join(tmpDir, "sourceFile")
-	require.NoError(t, fileutil.WriteStringToFile(sourceFile, ""))
-
-	destinationZip := filepath.Join(tmpDir, "destinationFile.zip")
-	require.NoError(t, ZipFile(sourceFile, destinationZip))
-
-	exist, err := pathutil.IsPathExists(destinationZip)
-	require.NoError(t, err)
-	require.Equal(t, true, exist)
-}
-
 func TestZipFiles(t *testing.T) {
-	t.Log("create zip from files in multiple directories")
+	t.Log("files from different directories are stored under their base names (junk paths)")
 	{
 		tmpDir, err := pathutil.NormalizedOSTempDirPath("test")
 		require.NoError(t, err)
 
-		sourceDir := filepath.Join(tmpDir, "sourceDir")
-		require.NoError(t, os.MkdirAll(sourceDir, 0777))
-
 		var sourceFilePaths []string
 		for _, name := range []string{"A", "B", "C"} {
-			baseDir := filepath.Join(sourceDir, name)
+			baseDir := filepath.Join(tmpDir, name)
 			require.NoError(t, pathutil.EnsureDirExist(baseDir))
 
 			sourceFile := filepath.Join(baseDir, "sourceFile"+name)
-			require.NoError(t, fileutil.WriteStringToFile(sourceFile, ""))
-
-			sourceFilePaths = append(sourceFilePaths, sourceFile)
-		}
-
-		destinationZip := filepath.Join(tmpDir, "destinationFile.zip")
-		require.NoError(t, ZipFiles(sourceFilePaths, destinationZip))
-
-		exist, err := pathutil.IsPathExists(destinationZip)
-		require.NoError(t, err)
-		require.Equal(t, true, exist)
-	}
-
-	t.Log("create zip from files in the same directory")
-	{
-		tmpDir, err := pathutil.NormalizedOSTempDirPath("test")
-		require.NoError(t, err)
-
-		sourceDir := filepath.Join(tmpDir, "sourceDir")
-		require.NoError(t, os.MkdirAll(sourceDir, 0777))
-
-		var sourceFilePaths []string
-		for _, name := range []string{"A", "B", "C"} {
-			sourceFile := filepath.Join(sourceDir, "sourceFile"+name)
 			require.NoError(t, fileutil.WriteStringToFile(sourceFile, name))
-
 			sourceFilePaths = append(sourceFilePaths, sourceFile)
 		}
 
-		destinationZip := filepath.Join(tmpDir, "destinationFile.zip")
+		destinationZip := filepath.Join(tmpDir, "dest.zip")
 		require.NoError(t, ZipFiles(sourceFilePaths, destinationZip))
 
-		exist, err := pathutil.IsPathExists(destinationZip)
+		unzipDir, err := pathutil.NormalizedOSTempDirPath("unzip")
 		require.NoError(t, err)
-		require.Equal(t, true, exist)
+		require.NoError(t, UnZip(destinationZip, unzipDir))
+
+		for _, name := range []string{"A", "B", "C"} {
+			content, err := fileutil.ReadStringFromFile(filepath.Join(unzipDir, "sourceFile"+name))
+			require.NoError(t, err)
+			require.Equal(t, name, content)
+		}
 	}
 
 	t.Log("create zip from files with the same name")
@@ -84,17 +47,13 @@ func TestZipFiles(t *testing.T) {
 		tmpDir, err := pathutil.NormalizedOSTempDirPath("test")
 		require.NoError(t, err)
 
-		sourceDir := filepath.Join(tmpDir, "sourceDir")
-		require.NoError(t, os.MkdirAll(sourceDir, 0777))
-
 		var sourceFilePaths []string
 		for _, name := range []string{"A", "B"} {
-			baseDir := filepath.Join(sourceDir, name)
+			baseDir := filepath.Join(tmpDir, name)
 			require.NoError(t, pathutil.EnsureDirExist(baseDir))
 
 			sourceFile := filepath.Join(baseDir, "sourceFile")
 			require.NoError(t, fileutil.WriteStringToFile(sourceFile, name))
-
 			sourceFilePaths = append(sourceFilePaths, sourceFile)
 		}
 
@@ -103,88 +62,36 @@ func TestZipFiles(t *testing.T) {
 	}
 }
 
-func TestZipDirectory(t *testing.T) {
-	t.Log("create zip from dir")
-	{
-		tmpDir, err := pathutil.NormalizedOSTempDirPath("test")
-		require.NoError(t, err)
-
-		sourceDir := filepath.Join(tmpDir, "sourceDir")
-		require.NoError(t, os.MkdirAll(sourceDir, 0777))
-
-		destinationZip := filepath.Join(tmpDir, "destinationDir.zip")
-		require.NoError(t, ZipDir(sourceDir, destinationZip, false))
-
-		exist, err := pathutil.IsPathExists(destinationZip)
-		require.NoError(t, err)
-		require.Equal(t, true, exist, destinationZip)
-	}
-
-	t.Log("zip content of dir")
-	{
-		tmpDir, err := pathutil.NormalizedOSTempDirPath("test")
-		require.NoError(t, err)
-
-		contentOfDirToZip := filepath.Join(tmpDir, "source")
-		require.NoError(t, os.MkdirAll(contentOfDirToZip, 0777))
-
-		sourceDir := filepath.Join(contentOfDirToZip, "sourceDir")
-		require.NoError(t, os.MkdirAll(sourceDir, 0777))
-
-		sourceFile := filepath.Join(sourceDir, "sourceFile")
-		require.NoError(t, fileutil.WriteStringToFile(sourceFile, ""))
-
-		destinationZip := filepath.Join(tmpDir, "destinationFile.zip")
-		require.NoError(t, ZipDir(contentOfDirToZip, destinationZip, true))
-	}
-}
-
 func TestZipDirectories(t *testing.T) {
-	t.Log("create zip from directories living at different places")
+	t.Log("dirs at different parent paths are each stored under their own basename")
 	{
 		tmpDir, err := pathutil.NormalizedOSTempDirPath("test")
 		require.NoError(t, err)
 
-		mainDir := filepath.Join(tmpDir, "main")
-		require.NoError(t, os.MkdirAll(mainDir, 0777))
-
-		dirA := filepath.Join(mainDir, "A")
-		require.NoError(t, os.MkdirAll(dirA, 0777))
+		dirA := filepath.Join(tmpDir, "main", "A")
+		require.NoError(t, os.MkdirAll(dirA, 0755))
+		require.NoError(t, fileutil.WriteStringToFile(filepath.Join(dirA, "fileA.txt"), "from_a"))
 
 		subDir := filepath.Join(tmpDir, "sub")
-		require.NoError(t, os.MkdirAll(mainDir, 0777))
-
+		require.NoError(t, os.MkdirAll(subDir, 0755))
 		dirB := filepath.Join(subDir, "B")
-		require.NoError(t, os.MkdirAll(dirB, 0777))
+		require.NoError(t, os.MkdirAll(dirB, 0755))
+		require.NoError(t, fileutil.WriteStringToFile(filepath.Join(dirB, "fileB.txt"), "from_b"))
 
-		destinationZip := filepath.Join(tmpDir, "destinationDir.zip")
+		destinationZip := filepath.Join(tmpDir, "dest.zip")
 		require.NoError(t, ZipDirs([]string{dirA, dirB}, destinationZip))
 
-		exist, err := pathutil.IsPathExists(destinationZip)
+		unzipDir, err := pathutil.NormalizedOSTempDirPath("unzip")
 		require.NoError(t, err)
-		require.Equal(t, true, exist, destinationZip)
-	}
+		require.NoError(t, UnZip(destinationZip, unzipDir))
 
-	t.Log("create zip from directories in the same parent directory")
-	{
-		tmpDir, err := pathutil.NormalizedOSTempDirPath("test")
+		contentA, err := fileutil.ReadStringFromFile(filepath.Join(unzipDir, "A", "fileA.txt"))
 		require.NoError(t, err)
+		require.Equal(t, "from_a", contentA)
 
-		mainDir := filepath.Join(tmpDir, "main")
-		require.NoError(t, os.MkdirAll(mainDir, 0777))
-
-		dirA := filepath.Join(mainDir, "A")
-		require.NoError(t, os.MkdirAll(dirA, 0777))
-
-		dirB := filepath.Join(mainDir, "B")
-		require.NoError(t, os.MkdirAll(dirB, 0777))
-
-		destinationZip := filepath.Join(tmpDir, "destinationDir.zip")
-		require.NoError(t, ZipDirs([]string{dirA, dirB}, destinationZip))
-
-		exist, err := pathutil.IsPathExists(destinationZip)
+		contentB, err := fileutil.ReadStringFromFile(filepath.Join(unzipDir, "B", "fileB.txt"))
 		require.NoError(t, err)
-		require.Equal(t, true, exist, destinationZip)
+		require.Equal(t, "from_b", contentB)
 	}
 }
 
@@ -194,21 +101,15 @@ func TestUnZipFile(t *testing.T) {
 		tmpDir, err := pathutil.NormalizedOSTempDirPath("test")
 		require.NoError(t, err)
 
-		// create file to zip tmp/source/sourceFile
-		contentOfDirToZip := filepath.Join(tmpDir, "source")
-		require.NoError(t, os.MkdirAll(contentOfDirToZip, 0777))
-
-		sourceFile := filepath.Join(contentOfDirToZip, "sourceFile")
+		sourceFile := filepath.Join(tmpDir, "source", "sourceFile")
+		require.NoError(t, os.MkdirAll(filepath.Dir(sourceFile), 0755))
 		require.NoError(t, fileutil.WriteStringToFile(sourceFile, ""))
 
-		// create zip at tmp/destinationFile.zip
 		destinationZip := filepath.Join(tmpDir, "destinationFile.zip")
 		require.NoError(t, ZipFile(sourceFile, destinationZip))
 
-		// unzip into tmp/
 		require.NoError(t, UnZip(destinationZip, tmpDir))
 
-		// tmp/sourceFile should exist
 		content, err := fileutil.ReadStringFromFile(filepath.Join(tmpDir, "sourceFile"))
 		require.NoError(t, err)
 		require.Equal(t, "", content)
@@ -219,23 +120,19 @@ func TestUnZipFile(t *testing.T) {
 		tmpDir, err := pathutil.NormalizedOSTempDirPath("test")
 		require.NoError(t, err)
 
-		// create file to zip tmp/source/sourceFile
-		contentOfDirToZip := filepath.Join(tmpDir, "source")
-		require.NoError(t, os.MkdirAll(contentOfDirToZip, 0777))
+		sourceDir := filepath.Join(tmpDir, "source")
+		require.NoError(t, os.MkdirAll(sourceDir, 0755))
 
 		var sourceFilePaths []string
 		for _, name := range []string{"A", "B", "C"} {
-			sourceFile := filepath.Join(contentOfDirToZip, "sourceFile"+name)
+			sourceFile := filepath.Join(sourceDir, "sourceFile"+name)
 			require.NoError(t, fileutil.WriteStringToFile(sourceFile, ""))
-
 			sourceFilePaths = append(sourceFilePaths, sourceFile)
 		}
 
-		// create zip at tmp/destinationFile.zip
 		destinationZip := filepath.Join(tmpDir, "destinationFile.zip")
 		require.NoError(t, ZipFiles(sourceFilePaths, destinationZip))
 
-		// unzip into tmp/
 		require.NoError(t, UnZip(destinationZip, tmpDir))
 
 		for _, path := range sourceFilePaths {
@@ -252,21 +149,14 @@ func TestUnZipDirectory(t *testing.T) {
 		tmpDir, err := pathutil.NormalizedOSTempDirPath("test")
 		require.NoError(t, err)
 
-		// create dir to zip tmp/source/sourceDir
-		contentOfDirToZip := filepath.Join(tmpDir, "source")
-		require.NoError(t, os.MkdirAll(contentOfDirToZip, 0777))
-
 		sourceDir := filepath.Join(tmpDir, "sourceDir")
 		require.NoError(t, os.MkdirAll(sourceDir, 0777))
 
-		// create zip at tmp/destinationDir.zip
-		destinationZip := filepath.Join(contentOfDirToZip, "destinationDir.zip")
+		destinationZip := filepath.Join(tmpDir, "destinationDir.zip")
 		require.NoError(t, ZipDir(sourceDir, destinationZip, false))
 
-		// unzip into tmp/
 		require.NoError(t, UnZip(destinationZip, tmpDir))
 
-		// tmp/sourceDir should exist
 		isDir, err := pathutil.IsDirExists(filepath.Join(tmpDir, "sourceDir"))
 		require.NoError(t, err)
 		require.Equal(t, true, isDir)
@@ -274,23 +164,18 @@ func TestUnZipDirectory(t *testing.T) {
 
 	t.Log("unzip zipped directories")
 	{
-		// Create the multi folder zip files
 		tmpDir, err := pathutil.NormalizedOSTempDirPath("zip")
 		require.NoError(t, err)
 
 		mainDir := filepath.Join(tmpDir, "main")
-		require.NoError(t, os.MkdirAll(mainDir, 0777))
-
 		dirA := filepath.Join(mainDir, "A")
 		require.NoError(t, os.MkdirAll(dirA, 0777))
-
 		dirB := filepath.Join(mainDir, "B")
 		require.NoError(t, os.MkdirAll(dirB, 0777))
 
 		destinationZip := filepath.Join(tmpDir, "destinationDir.zip")
 		require.NoError(t, ZipDirs([]string{dirA, dirB}, destinationZip))
 
-		// unzip
 		destTmpDir, err := pathutil.NormalizedOSTempDirPath("unzip")
 		require.NoError(t, err)
 
@@ -310,33 +195,26 @@ func TestUnZipDirectory(t *testing.T) {
 		tmpDir, err := pathutil.NormalizedOSTempDirPath("test")
 		require.NoError(t, err)
 
-		// create dir to zip tmp/source/sourceDir
 		contentOfDirToZip := filepath.Join(tmpDir, "source")
 		require.NoError(t, os.MkdirAll(contentOfDirToZip, 0777))
 
 		sourceDir := filepath.Join(contentOfDirToZip, "sourceDir")
 		require.NoError(t, os.MkdirAll(sourceDir, 0777))
 
-		// create file to zip tmp/source/sourceFile
 		sourceFile := filepath.Join(contentOfDirToZip, "sourceFile")
 		require.NoError(t, fileutil.WriteStringToFile(sourceFile, ""))
 
-		// create zip at tmp/destinationDir.zip
 		destinationZip := filepath.Join(tmpDir, "destinationFile.zip")
 		require.NoError(t, ZipDir(contentOfDirToZip, destinationZip, true))
 
-		// remove tmp/source, since this path would be the unzip destination
 		require.NoError(t, os.RemoveAll(contentOfDirToZip))
 
-		// unzip into tmp/
 		require.NoError(t, UnZip(destinationZip, tmpDir))
 
-		// tmp/sourceDir should exist
 		isDir, err := pathutil.IsDirExists(filepath.Join(tmpDir, "sourceDir"))
 		require.NoError(t, err)
 		require.Equal(t, true, isDir)
 
-		// tmp/sourceFile should exist
 		content, err := fileutil.ReadStringFromFile(filepath.Join(tmpDir, "sourceFile"))
 		require.NoError(t, err)
 		require.Equal(t, "", content)
@@ -344,7 +222,6 @@ func TestUnZipDirectory(t *testing.T) {
 
 	t.Log("unzip into different dir")
 	{
-		// create zip at tmp dir (tmp1)
 		sourceTmpDir, err := pathutil.NormalizedOSTempDirPath("__1__")
 		require.NoError(t, err)
 
@@ -353,9 +230,7 @@ func TestUnZipDirectory(t *testing.T) {
 
 		destinationZip := filepath.Join(sourceTmpDir, "destinationFile.zip")
 		require.NoError(t, ZipFile(sourceFile, destinationZip))
-		// ---
 
-		// unzip into another tmp dir (tmp2)
 		destTmpDir, err := pathutil.NormalizedOSTempDirPath("__2__")
 		require.NoError(t, err)
 
@@ -363,12 +238,10 @@ func TestUnZipDirectory(t *testing.T) {
 		exist, err := pathutil.IsPathExists(filepath.Join(destTmpDir, "sourceFile"))
 		require.NoError(t, err)
 		require.Equal(t, true, exist)
-		// ---
 	}
 
 	t.Log("relative path")
 	{
-		// create zip at tmp dir (tmp1) - using relative path
 		sourceTmpDir, err := pathutil.NormalizedOSTempDirPath("__1__")
 		require.NoError(t, err)
 
@@ -382,16 +255,12 @@ func TestUnZipDirectory(t *testing.T) {
 		require.NoError(t, fileutil.WriteStringToFile(sourceFile, ""))
 
 		require.NoError(t, ZipFile("./sourceFile", "./destinationFile.zip"))
-		// ---
 
-		// unzip into the same tmp dir (tmp1)
 		require.NoError(t, UnZip("./destinationFile.zip", "./unzipped"))
 		exist, err := pathutil.IsPathExists("./unzipped/sourceFile")
 		require.NoError(t, err)
 		require.Equal(t, true, exist)
-		// ---
 
-		// unzip into another tmp dir (tmp2)
 		destTmpDir, err := pathutil.NormalizedOSTempDirPath("__2__")
 		require.NoError(t, err)
 
@@ -401,12 +270,9 @@ func TestUnZipDirectory(t *testing.T) {
 		require.Equal(t, true, exist)
 
 		require.NoError(t, revokeFn())
-		// ---
 	}
 }
 
-// TestZipDirPreservesDirMtime verifies that directory entry modification times are stored
-// in the archive.
 func TestZipDirPreservesDirMtime(t *testing.T) {
 	tmpDir, err := pathutil.NormalizedOSTempDirPath("test")
 	require.NoError(t, err)

--- a/ziputil/ziputil_test.go
+++ b/ziputil/ziputil_test.go
@@ -42,7 +42,7 @@ func TestZipFiles(t *testing.T) {
 		}
 	}
 
-	t.Log("create zip from files with the same name")
+	t.Log("duplicate base names cause an error")
 	{
 		tmpDir, err := pathutil.NormalizedOSTempDirPath("test")
 		require.NoError(t, err)
@@ -284,8 +284,7 @@ func TestZipDirPreservesDirMtime(t *testing.T) {
 	require.NoError(t, os.Chtimes(sourceDir, knownTime, knownTime))
 
 	destinationZip := filepath.Join(tmpDir, "out.zip")
-	// isContentOnly=true so sourceDir/ is a direct top-level entry with a predictable name.
-	require.NoError(t, ZipDir(tmpDir, destinationZip, true))
+	require.NoError(t, ZipDir(sourceDir, destinationZip, false))
 
 	r, err := zip.OpenReader(destinationZip)
 	require.NoError(t, err)


### PR DESCRIPTION
Replace placeholder `...` comments with accurate documentation for all public functions. Document non-obvious behaviors: `isContentOnly` archive structure, `ZipDirs` rsync-based merge semantics and `log.Fatal` on cleanup failure, `ZipFiles` no-output guarantee on duplicate basenames, and `UnZip` zip-slip strip-and-continue behavior. Tighten inline flag comments (`-r`, `-T`, `-y`, `-j`) to describe what each flag actually does.

Rewrite the test file: remove weak tests that only assert the output file exists (all covered by existing round-trip tests), strengthen two unique scenarios into proper round-trips with content checks, fix a `os.MkdirAll` copy-paste bug, and add four new tests that lock in the behaviors above: directory mtime preservation, same-basename directory merge, no output file on duplicate basename error, and zip-slip strip-and-extract.