### PR TITLE
[STEP-2374] Export CopyFileFS to copy a single file from an fs.FS source

### DIFF
--- a/fileutil/copy.go
+++ b/fileutil/copy.go
@@ -21,12 +21,21 @@ func (fm fileManager) CopyFile(src, dst string, opts *CopyOptions) error {
 	srcDir := filepath.Dir(src)
 	fsys := fm.osProxy.DirFS(srcDir)
 
-	return fm.copyFileFS(fsys, filepath.Base(src), dst, opts)
+	return fm.CopyFileFS(fsys, filepath.Base(src), dst, opts)
 }
 
-// copyFileFS is the excerpt from fs.CopyFS that copies a single file from fs.FS to dst path.
-// The [CopyOptions] parameter is used to modify default behavior as required or keep the default when nil is provided.
-func (fm fileManager) copyFileFS(fsys fs.FS, src, dst string, opts *CopyOptions) error {
+// CopyFileFS copies a single file located at src within the source file system fsys to dst.
+// It is the excerpt from fs.CopyFS that copies a single file from an fs.FS to a dst path.
+// Pass [CopyOptions] to modify default behavior as required, nil otherwise.
+//
+// By default, if the target file exists, this call will fail with an error.
+// Use [CopyOptions.Overwrite] to replace an existing destination file instead.
+//
+// Note: ownership and access/modification time preservation rely on the source FS
+// exposing a *syscall.Stat_t via fs.FileInfo.Sys() (as os-backed file systems such as
+// os.DirFS do). When copying from in-memory file systems (e.g. embed.FS or fstest.MapFS)
+// that information is unavailable, so ownership and times are simply not preserved.
+func (fm fileManager) CopyFileFS(fsys fs.FS, src, dst string, opts *CopyOptions) error {
 	r, err := fsys.Open(src)
 	if err != nil {
 		return err
@@ -132,7 +141,7 @@ func (fm fileManager) CopyDir(src, dst string, opts *CopyOptions) error {
 
 		// "normal" file
 		case 0:
-			return fm.copyFileFS(fsys, path, newPath, opts)
+			return fm.CopyFileFS(fsys, path, newPath, opts)
 
 		default:
 			return &os.PathError{Op: "CopyFS", Path: path, Err: os.ErrInvalid}
@@ -152,7 +161,10 @@ func (fm fileManager) copyOwner(srcInfo os.FileInfo, dstPath string) error {
 	}
 	stat, ok := srcInfo.Sys().(*syscall.Stat_t)
 	if !ok {
-		return fmt.Errorf("missing Stat_t for symlink %s", dstPath)
+		// Source file systems that are not backed by the OS (e.g. embed.FS or
+		// fstest.MapFS) do not expose a *syscall.Stat_t, so there is no ownership
+		// information to copy. Skip ownership preservation in that case.
+		return nil
 	}
 	// os.Lchown affects the link itself when given the link path
 	if err := fm.lchown(dstPath, int(stat.Uid), int(stat.Gid)); err != nil {

--- a/fileutil/copy_test.go
+++ b/fileutil/copy_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"testing/fstest"
 
 	"github.com/bitrise-io/go-utils/v2/fileutil/mocks/osproxy"
 	"github.com/stretchr/testify/assert"
@@ -165,6 +166,90 @@ func TestCopyFile_GivenDstFileTimesChangeFailure_WillFail(t *testing.T) {
 	osProxy.EXPECT().Chtimes(filepath.Join(dstDir, "file1"), mock.Anything, mock.Anything).Return(os.ErrPermission).Once()
 
 	assert.ErrorContains(t, sut.CopyFile(srcDir+"/file1", dstDir+"/file1", nil), os.ErrPermission.Error())
+}
+
+func TestCopyFileFS(t *testing.T) {
+	tmpDir := t.TempDir()
+	srcDir := createSrcDirWithFiles(t, t.TempDir(), []string{"file1"})
+	dstDir := filepath.Join(tmpDir, "dst-dir")
+	assert.NoError(t, os.MkdirAll(dstDir, 0755))
+
+	osProxy := osproxy.NewOsProxy(t)
+
+	sut := fileManager{osProxy: osProxy}
+
+	// Expect dst file open for writing
+	osProxy.EXPECT().
+		OpenFile(filepath.Join(dstDir, "file1"), mock.Anything, mock.Anything).
+		Return(os.OpenFile(filepath.Join(dstDir, "file1"), os.O_CREATE|os.O_EXCL|os.O_WRONLY, os.FileMode(0o777))).
+		Once()
+
+	// Expect dst file ownership, permissions and times to be set
+	osProxy.EXPECT().Lchown(filepath.Join(dstDir, "file1"), mock.Anything, mock.Anything).Return(nil).Once()
+	osProxy.EXPECT().Chmod(filepath.Join(dstDir, "file1"), mock.Anything).Return(nil).Once()
+	osProxy.EXPECT().Chtimes(filepath.Join(dstDir, "file1"), mock.Anything, mock.Anything).Return(nil).Once()
+
+	assert.NoError(t, sut.CopyFileFS(os.DirFS(srcDir), "file1", filepath.Join(dstDir, "file1"), nil))
+}
+
+func TestCopyFileFS_WithOverwrite(t *testing.T) {
+	tmpDir := t.TempDir()
+	srcDir := createSrcDirWithFiles(t, t.TempDir(), []string{"file1"})
+	dstDir := filepath.Join(tmpDir, "dst-dir")
+	assert.NoError(t, os.MkdirAll(dstDir, 0755))
+	// Pre-create the destination file so overwrite is exercised
+	require.NoError(t, os.WriteFile(filepath.Join(dstDir, "file1"), []byte("old"), 0644))
+
+	osProxy := osproxy.NewOsProxy(t)
+
+	sut := fileManager{osProxy: osProxy}
+
+	// Expect dst file open for writing with TRUNC flag (overwrite)
+	osProxy.EXPECT().
+		OpenFile(filepath.Join(dstDir, "file1"), os.O_CREATE|os.O_TRUNC|os.O_WRONLY, mock.Anything).
+		Return(os.OpenFile(filepath.Join(dstDir, "file1"), os.O_CREATE|os.O_TRUNC|os.O_WRONLY, os.FileMode(0o777))).
+		Once()
+
+	// Expect dst file ownership, permissions and times to be set
+	osProxy.EXPECT().Lchown(filepath.Join(dstDir, "file1"), mock.Anything, mock.Anything).Return(nil).Once()
+	osProxy.EXPECT().Chmod(filepath.Join(dstDir, "file1"), mock.Anything).Return(nil).Once()
+	osProxy.EXPECT().Chtimes(filepath.Join(dstDir, "file1"), mock.Anything, mock.Anything).Return(nil).Once()
+
+	assert.NoError(t, sut.CopyFileFS(os.DirFS(srcDir), "file1", filepath.Join(dstDir, "file1"), &CopyOptions{Overwrite: true}))
+}
+
+func TestCopyFileFS_GivenInMemoryFS_SkipsOwnershipPreservation(t *testing.T) {
+	dstDir := t.TempDir()
+
+	osProxy := osproxy.NewOsProxy(t)
+
+	sut := fileManager{osProxy: osProxy}
+
+	// fstest.MapFS does not expose a *syscall.Stat_t, so ownership and times
+	// cannot be preserved. Lchown and Chtimes must not be called, while the file
+	// mode is still set.
+	osProxy.EXPECT().
+		OpenFile(filepath.Join(dstDir, "file1"), mock.Anything, mock.Anything).
+		Return(os.OpenFile(filepath.Join(dstDir, "file1"), os.O_CREATE|os.O_EXCL|os.O_WRONLY, os.FileMode(0o777))).
+		Once()
+	osProxy.EXPECT().Chmod(filepath.Join(dstDir, "file1"), mock.Anything).Return(nil).Once()
+
+	srcFS := fstest.MapFS{"file1": {Data: []byte("hello")}}
+
+	assert.NoError(t, sut.CopyFileFS(srcFS, "file1", filepath.Join(dstDir, "file1"), nil))
+}
+
+func TestCopyFileFS_GivenMissingSrc_WillFail(t *testing.T) {
+	tmpDir := t.TempDir()
+	srcDir := createSrcDirWithFiles(t, t.TempDir(), []string{"file1"})
+	dstDir := filepath.Join(tmpDir, "dst-dir")
+	assert.NoError(t, os.MkdirAll(dstDir, 0755))
+
+	osProxy := osproxy.NewOsProxy(t)
+
+	sut := fileManager{osProxy: osProxy}
+
+	assert.Error(t, sut.CopyFileFS(os.DirFS(srcDir), "missing", filepath.Join(dstDir, "missing"), nil))
 }
 
 func TestCopyDir(t *testing.T) {

--- a/fileutil/fileutil.go
+++ b/fileutil/fileutil.go
@@ -26,6 +26,7 @@ type FileManager interface {
 	WriteBytes(path string, value []byte) error
 	FileSizeInBytes(pth string) (int64, error)
 	CopyFile(src, dst string, opts *CopyOptions) error
+	CopyFileFS(fsys fs.FS, src, dst string, opts *CopyOptions) error
 	CopyDir(src, dst string, opts *CopyOptions) error
 	Lstat(path string) (os.FileInfo, error)
 	LastNLines(s string, n int) string

--- a/fileutil/mocks/FileManager.go
+++ b/fileutil/mocks/FileManager.go
@@ -6,9 +6,10 @@ package mocks
 
 import (
 	"io"
+	"io/fs"
 	"os"
 
-	fileutil "github.com/bitrise-io/go-utils/v2/fileutil"
+	"github.com/bitrise-io/go-utils/v2/fileutil"
 	mock "github.com/stretchr/testify/mock"
 )
 
@@ -161,6 +162,75 @@ func (_c *FileManager_CopyFile_Call) Return(err error) *FileManager_CopyFile_Cal
 }
 
 func (_c *FileManager_CopyFile_Call) RunAndReturn(run func(src string, dst string, opts *fileutil.CopyOptions) error) *FileManager_CopyFile_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// CopyFileFS provides a mock function for the type FileManager
+func (_mock *FileManager) CopyFileFS(fsys fs.FS, src string, dst string, opts *fileutil.CopyOptions) error {
+	ret := _mock.Called(fsys, src, dst, opts)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CopyFileFS")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(fs.FS, string, string, *fileutil.CopyOptions) error); ok {
+		r0 = returnFunc(fsys, src, dst, opts)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// FileManager_CopyFileFS_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CopyFileFS'
+type FileManager_CopyFileFS_Call struct {
+	*mock.Call
+}
+
+// CopyFileFS is a helper method to define mock.On call
+//   - fsys fs.FS
+//   - src string
+//   - dst string
+//   - opts *fileutil.CopyOptions
+func (_e *FileManager_Expecter) CopyFileFS(fsys interface{}, src interface{}, dst interface{}, opts interface{}) *FileManager_CopyFileFS_Call {
+	return &FileManager_CopyFileFS_Call{Call: _e.mock.On("CopyFileFS", fsys, src, dst, opts)}
+}
+
+func (_c *FileManager_CopyFileFS_Call) Run(run func(fsys fs.FS, src string, dst string, opts *fileutil.CopyOptions)) *FileManager_CopyFileFS_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 fs.FS
+		if args[0] != nil {
+			arg0 = args[0].(fs.FS)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		var arg3 *fileutil.CopyOptions
+		if args[3] != nil {
+			arg3 = args[3].(*fileutil.CopyOptions)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+			arg3,
+		)
+	})
+	return _c
+}
+
+func (_c *FileManager_CopyFileFS_Call) Return(err error) *FileManager_CopyFileFS_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *FileManager_CopyFileFS_Call) RunAndReturn(run func(fsys fs.FS, src string, dst string, opts *fileutil.CopyOptions) error) *FileManager_CopyFileFS_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
## What

Promotes the internal `copyFileFS` helper to an exported `FileManager.CopyFileFS` method that copies a single file from an `fs.FS` source to a destination path, complementing the existing `CopyFile` (which takes a source path string).

## Why

Enables copying a single file directly from any `fs.FS` — including non-OS-backed file systems such as `embed.FS` and `fstest.MapFS` — without first materializing it on disk.

## Details

- Exports the existing internal `copyFileFS` helper as a public method (named `CopyFileFS` to mirror the helper and the stdlib `fs.CopyFS` convention). `CopyFile` and `CopyDir` call it directly, so there's no thin wrapper.
- `copyOwner` now skips ownership preservation when the source `FileInfo` carries no `*syscall.Stat_t` (instead of erroring), so copying from in-memory file systems works. In that case ownership and access/modification times are simply not preserved. This is transparent to `CopyFile`/`CopyDir`, which use `os.DirFS` and always carry a `Stat_t`.
- Regenerated the `FileManager` mock via mockery.
- Added tests covering the default copy, overwrite, in-memory FS (ownership/times skipped), and missing-source cases.

### Note on a writable destination

The destination stays a path string because the stdlib `io/fs.FS` is read-only (`fs.FS`/`fs.File` expose no write/create/chmod operations), so an `fs.FS` cannot be a copy target without introducing a separate writable-filesystem abstraction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)